### PR TITLE
LNIT-8-로그인-회원가입-API-구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 	// Caffeine Cache
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'com.github.ben-manes.caffeine:caffeine'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.depth.learningcrew.domain.auth.controller;
+
+import com.depth.learningcrew.domain.auth.dto.AuthDto;
+import com.depth.learningcrew.domain.auth.service.AuthService;
+import com.depth.learningcrew.domain.user.dto.UserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "인증/인가 API")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+    @ApiResponse(responseCode = "200", description = "회원가입 성공")
+    public UserDto.UserResponse signUp(@RequestBody @Valid AuthDto.SignUpRequest request) {
+        return authService.signUp(request);
+    }
+}

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -7,10 +7,14 @@ import com.depth.learningcrew.system.security.model.JwtDto;
 import com.depth.learningcrew.system.security.model.UserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -57,5 +61,24 @@ public class AuthController {
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         return UserDto.UserResponse.from(userDetails.getUser());
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "현재 사용자의 Refresh Token을 삭제하며 로그아웃 처리합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그아웃 성공",
+            content = @Content(
+                    mediaType = "text/plain",
+                    examples = @ExampleObject(value = "Logout Successful")
+            )
+    )
+    public ResponseEntity<String> logout(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetails userDetails,
+            HttpServletRequest request
+    ) {
+        authService.logout(userDetails, request);
+        return ResponseEntity.ok("Logout Successful");
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,5 +29,12 @@ public class AuthController {
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     public AuthDto.SignInResponse signIn(@RequestBody @Valid AuthDto.SignInRequest request) {
         return authService.signIn(request);
+    }
+
+    @GetMapping("/id-exist")
+    @Operation(summary = "아이디 중복 확인", description = "입력된 아이디의 사용 가능 여부를 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "아이디 확인 성공")
+    public AuthDto.IdExistResponse checkId(@RequestBody @Valid AuthDto.IdExistRequest request) {
+        return authService.checkIdExist(request);
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.depth.learningcrew.domain.auth.controller;
 import com.depth.learningcrew.domain.auth.dto.AuthDto;
 import com.depth.learningcrew.domain.auth.service.AuthService;
 import com.depth.learningcrew.domain.user.dto.UserDto;
+import com.depth.learningcrew.system.security.model.JwtDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,5 +37,12 @@ public class AuthController {
     @ApiResponse(responseCode = "200", description = "아이디 확인 성공")
     public AuthDto.IdExistResponse checkId(@RequestBody @Valid AuthDto.IdExistRequest request) {
         return authService.checkIdExist(request);
+    }
+
+    @PostMapping("/token/refresh")
+    @Operation(summary = "토큰 재발행", description = "새로운 Access/Refresh Token을 재발급받습니다.")
+    @ApiResponse(responseCode = "200", description = "토큰 재발행 성공")
+    public JwtDto.TokenInfo refreshToken(@RequestBody @Valid AuthDto.RecreateRequest request) {
+        return authService.recreateToken(request);
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -26,4 +26,11 @@ public class AuthController {
     public UserDto.UserResponse signUp(@RequestBody @Valid AuthDto.SignUpRequest request) {
         return authService.signUp(request);
     }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    public AuthDto.SignInResponse signIn(@RequestBody @Valid AuthDto.SignInRequest request) {
+        return authService.signIn(request);
+    }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -4,11 +4,14 @@ import com.depth.learningcrew.domain.auth.dto.AuthDto;
 import com.depth.learningcrew.domain.auth.service.AuthService;
 import com.depth.learningcrew.domain.user.dto.UserDto;
 import com.depth.learningcrew.system.security.model.JwtDto;
+import com.depth.learningcrew.system.security.model.UserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -44,5 +47,15 @@ public class AuthController {
     @ApiResponse(responseCode = "200", description = "토큰 재발행 성공")
     public JwtDto.TokenInfo refreshToken(@RequestBody @Valid AuthDto.RecreateRequest request) {
         return authService.recreateToken(request);
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "내 정보 조회 성공")
+    public UserDto.UserResponse whoami(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        return UserDto.UserResponse.from(userDetails.getUser());
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -1,8 +1,13 @@
 package com.depth.learningcrew.domain.auth.dto;
 
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
 import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class AuthDto {
@@ -11,11 +16,8 @@ public class AuthDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    @Getter
     @Schema(description = "토큰 재발행 DTO")
     public static class RecreateRequest {
-        @Schema(description = "확인할 ID", example = "dev1234")
-        private String id;
         @Schema(description = "재발행할 Refresh Token", example = "refreshTokenString")
         private String refreshToken;
     }
@@ -24,7 +26,6 @@ public class AuthDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    @Getter
     @Schema(description = "토큰 정보 DTO")
     public static class TokenInfo {
         @Schema(description = "발급된 Access Token")
@@ -50,6 +51,52 @@ public class AuthDto {
                     .refreshToken(refreshToken)
                     .accessTokenExpiresAt(accessTokenExpiresAt)
                     .refreshTokenExpiresAt(refreshTokenExpiresAt)
+                    .build();
+        }
+    }
+
+    // 회원가입 요청 DTO
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "회원가입 요청 DTO")
+    public static class SignUpRequest {
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "learnit@mju.ac.kr")
+        private String id;
+
+        @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
+        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
+        @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
+        private String nickname;
+
+        @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
+        @Schema(description = "사용자 비밀번호", example = "newpassword123 || NewPassword123")
+        private String password;
+
+        @NotNull(message = "생년월일을 입력해주세요.")
+        @Schema(description = "사용자 생년월일", example = "2000-01-01")
+        private LocalDate birthday;
+
+        @NotNull(message = "성별을 입력해주세요.")
+        @Schema(
+                description = "사용자 성별",
+                example = "MALE",
+                allowableValues = {"MALE", "FEMALE", "OTHER"}
+        )
+        private Gender gender;
+
+
+        public User toEntity(PasswordEncoder encoder) {
+            return User.builder()
+                    .id(id)
+                    .nickname(nickname)
+                    .password(encoder.encode(password))
+                    .birthday(birthday)
+                    .gender(gender)
                     .build();
         }
     }

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -86,11 +86,11 @@ public class AuthDto {
     @Builder
     @Schema(description = "로그인 응답 DTO")
     public static class SignInResponse {
-        @Schema(description = "발급된 토큰 정보", implementation = JwtDto.TokenInfo.class)
-        private JwtDto.TokenInfo token;
-
         @Schema(description = "로그인한 사용자 정보", implementation = UserDto.UserResponse.class)
         private UserDto.UserResponse user;
+
+        @Schema(description = "발급된 토큰 정보", implementation = JwtDto.TokenInfo.class)
+        private JwtDto.TokenInfo token;
 
         public static SignInResponse of(
                 UserDto.UserResponse user,

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -143,4 +143,33 @@ public class AuthDto {
                     .build();
         }
     }
+
+    // 아이디 중복 인증 확인 요청 DTO
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "아이디 중복 확인 요청 DTO")
+    public static class IdExistRequest {
+        @NotBlank(message = "확인할 아이디(이메일 주소)를 입력해주세요.")
+        @Schema(description = "확인할 아이디(이메일 주소)", example = "learnit@mju.ac.kr")
+        private String id;
+    }
+
+    // 아이디 중복 인증 확인 응답 DTO
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "아이디 중복 확인 응답 DTO")
+    public static class IdExistResponse {
+        @Schema(description = "아이디 존재 여부 (true/false)", example = "false")
+        private boolean isExist;
+
+        public static IdExistResponse from(boolean exists) {
+            return IdExistResponse.builder()
+                    .isExist(exists)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -1,7 +1,9 @@
 package com.depth.learningcrew.domain.auth.dto;
 
+import com.depth.learningcrew.domain.user.dto.UserDto;
 import com.depth.learningcrew.domain.user.entity.Gender;
 import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.system.security.model.JwtDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.*;
@@ -18,6 +20,7 @@ public class AuthDto {
     @Builder
     @Schema(description = "토큰 재발행 DTO")
     public static class RecreateRequest {
+        @NotBlank(message = "Refresh Token을 입력해주세요.")
         @Schema(description = "재발행할 Refresh Token", example = "refreshTokenString")
         private String refreshToken;
     }
@@ -28,16 +31,13 @@ public class AuthDto {
     @Builder
     @Schema(description = "토큰 정보 DTO")
     public static class TokenInfo {
-        @Schema(description = "발급된 Access Token")
+        @Schema(description = "발급된 Access Token", example = "ehJk2Y3Rlc3Q1qW.NjZXNzVG9rZW4=")
         private String accessToken;
-
-        @Schema(description = "발급된 Refresh Token")
+        @Schema(description = "발급된 Refresh Token", example = "ehJk2Y3Rlc3Q1qW.Aw5pdGlhbE9iamVjdA==")
         private String refreshToken;
-
-        @Schema(description = "Access Token 만료 시간")
+        @Schema(description = "Access Token 만료 시간", example = "2023-10-01T12:00:00")
         private LocalDateTime accessTokenExpiresAt;
-
-        @Schema(description = "Refresh Token 만료 시간")
+        @Schema(description = "Refresh Token 만료 시간", example = "2023-12-01T12:00:00")
         private LocalDateTime refreshTokenExpiresAt;
 
         public static TokenInfo of(
@@ -97,6 +97,49 @@ public class AuthDto {
                     .password(encoder.encode(password))
                     .birthday(birthday)
                     .gender(gender)
+                    .build();
+        }
+    }
+
+    // 로그인 요청 DTO
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "로그인 요청 DTO")
+    public static class SignInRequest {
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "learnit@mju.ac.kr")
+        private String id;
+
+        @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
+        @Schema(description = "사용자 비밀번호", example = "newpassword123 || NewPassword123")
+        private String password;
+
+    }
+
+    // 로그인 응답 DTO
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "로그인 응답 DTO")
+    public static class SignInResponse {
+        @Schema(description = "발급된 토큰 정보", implementation = TokenInfo.class)
+        private AuthDto.TokenInfo token;
+
+        @Schema(description = "로그인한 사용자 정보", implementation = UserDto.UserResponse.class)
+        private UserDto.UserResponse user;
+
+        public static SignInResponse of(
+                UserDto.UserResponse user,
+                AuthDto.TokenInfo token
+        ) {
+            return SignInResponse.builder()
+                    .user(user)
+                    .token(token)
                     .build();
         }
     }

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -14,47 +14,6 @@ import java.time.LocalDateTime;
 
 public class AuthDto {
 
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    @Schema(description = "토큰 재발행 DTO")
-    public static class RecreateRequest {
-        @NotBlank(message = "Refresh Token을 입력해주세요.")
-        @Schema(description = "재발행할 Refresh Token", example = "refreshTokenString")
-        private String refreshToken;
-    }
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    @Schema(description = "토큰 정보 DTO")
-    public static class TokenInfo {
-        @Schema(description = "발급된 Access Token", example = "ehJk2Y3Rlc3Q1qW.NjZXNzVG9rZW4=")
-        private String accessToken;
-        @Schema(description = "발급된 Refresh Token", example = "ehJk2Y3Rlc3Q1qW.Aw5pdGlhbE9iamVjdA==")
-        private String refreshToken;
-        @Schema(description = "Access Token 만료 시간", example = "2023-10-01T12:00:00")
-        private LocalDateTime accessTokenExpiresAt;
-        @Schema(description = "Refresh Token 만료 시간", example = "2023-12-01T12:00:00")
-        private LocalDateTime refreshTokenExpiresAt;
-
-        public static TokenInfo of(
-                String accessToken,
-                String refreshToken,
-                LocalDateTime accessTokenExpiresAt,
-                LocalDateTime refreshTokenExpiresAt
-        ) {
-            return TokenInfo.builder()
-                    .accessToken(accessToken)
-                    .refreshToken(refreshToken)
-                    .accessTokenExpiresAt(accessTokenExpiresAt)
-                    .refreshTokenExpiresAt(refreshTokenExpiresAt)
-                    .build();
-        }
-    }
-
     // 회원가입 요청 DTO
     @Data
     @AllArgsConstructor
@@ -127,15 +86,15 @@ public class AuthDto {
     @Builder
     @Schema(description = "로그인 응답 DTO")
     public static class SignInResponse {
-        @Schema(description = "발급된 토큰 정보", implementation = TokenInfo.class)
-        private AuthDto.TokenInfo token;
+        @Schema(description = "발급된 토큰 정보", implementation = JwtDto.TokenInfo.class)
+        private JwtDto.TokenInfo token;
 
         @Schema(description = "로그인한 사용자 정보", implementation = UserDto.UserResponse.class)
         private UserDto.UserResponse user;
 
         public static SignInResponse of(
                 UserDto.UserResponse user,
-                AuthDto.TokenInfo token
+                JwtDto.TokenInfo token
         ) {
             return SignInResponse.builder()
                     .user(user)
@@ -171,5 +130,16 @@ public class AuthDto {
                     .isExist(exists)
                     .build();
         }
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "토큰 재발행 DTO")
+    public static class RecreateRequest {
+        @NotBlank(message = "Refresh Token을 입력해주세요.")
+        @Schema(description = "재발행할 Refresh Token", example = "refreshTokenString")
+        private String refreshToken;
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -111,6 +111,7 @@ public class AuthDto {
     @Schema(description = "아이디 중복 확인 요청 DTO")
     public static class IdExistRequest {
         @NotBlank(message = "확인할 아이디(이메일 주소)를 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         @Schema(description = "확인할 아이디(이메일 주소)", example = "learnit@mju.ac.kr")
         private String id;
     }

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -21,7 +21,7 @@ public class AuthDto {
     @Builder
     @Schema(description = "회원가입 요청 DTO")
     public static class SignUpRequest {
-        @NotBlank(message = "이메일을 입력해주세요.")
+        @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         @Schema(description = "사용자 아이디(이메일 형식)", example = "learnit@mju.ac.kr")
         private String id;

--- a/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
@@ -109,4 +109,10 @@ public class AuthService {
 
         return AuthDto.SignInResponse.of(UserDto.UserResponse.from(found), tokenInfo);
     }
+
+    @Transactional(readOnly = true)
+    public AuthDto.IdExistResponse checkIdExist(AuthDto.IdExistRequest request) {
+        boolean exists = userRepository.existsById(request.getId());
+        return AuthDto.IdExistResponse.from(exists);
+    }
 }

--- a/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
@@ -70,7 +70,7 @@ public class AuthService {
     public UserDto.UserResponse signUp(AuthDto.SignUpRequest request) {
         boolean isExisting = userRepository.existsById(request.getId());
         if(isExisting)
-            throw new RestException(ErrorCode.GLOBAL_ALREADY_EXIST);
+            throw new RestException(ErrorCode.USER_ALREADY_ID_EXISTS);
 
         User toSave = request.toEntity(passwordEncoder);
         User saved = userRepository.save(toSave);

--- a/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
@@ -41,7 +41,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public JwtDto.TokenPair recreateToken(AuthDto.RecreateRequest request){
+    public JwtDto.TokenInfo recreateToken(AuthDto.RecreateRequest request){
         String refreshTokenUuid = request.getRefreshToken();
         String id = jwtTokenResolver.resolveTokenFromString(refreshTokenUuid).getSubject();
 
@@ -63,7 +63,7 @@ public class AuthService {
         refreshTokenRepository.save(newRefreshToken);
         refreshTokenCacheRepository.cacheRefreshUuid(newRefreshUuid, userDetails.getKey());
 
-        return tokenPair;
+        return JwtDto.TokenInfo.of(tokenPair);
     }
 
     @Transactional
@@ -100,14 +100,7 @@ public class AuthService {
         refreshTokenRepository.save(refreshToken);
         refreshTokenCacheRepository.cacheRefreshUuid(refreshUuid, userDetails.getKey());
 
-        AuthDto.TokenInfo tokenInfo = AuthDto.TokenInfo.builder()
-                .accessToken(tokenPair.getAccessToken().getTokenString())
-                .refreshToken(tokenPair.getRefreshToken().getTokenString())
-                .accessTokenExpiresAt(tokenPair.getAccessToken().getExpireAt())
-                .refreshTokenExpiresAt(tokenPair.getRefreshToken().getExpireAt())
-                .build();
-
-        return AuthDto.SignInResponse.of(UserDto.UserResponse.from(found), tokenInfo);
+        return AuthDto.SignInResponse.of(UserDto.UserResponse.from(found), JwtDto.TokenInfo.of(tokenPair));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -1,0 +1,36 @@
+package com.depth.learningcrew.domain.user.dto;
+
+import com.depth.learningcrew.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class UserDto {
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class UserResponse {
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "learnit@mju.ac.kr")
+        private String id;
+        @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
+        private String nickname;
+        @Schema(description = "계정 생성 시간")
+        private LocalDateTime createdAt;
+        @Schema(description = "마지막 정보 수정 시간")
+        private LocalDateTime lastModifiedAt;
+
+        public static UserResponse from(User user) {
+            return UserResponse.builder()
+                    .id(user.getId())
+                    .nickname(user.getNickname())
+                    .createdAt(user.getCreatedAt())
+                    .lastModifiedAt(user.getLastModifiedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -19,9 +19,9 @@ public class UserDto {
         private String id;
         @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
         private String nickname;
-        @Schema(description = "계정 생성 시간")
+        @Schema(description = "계정 생성 시간", example = "2025-10-01T12:00:00")
         private LocalDateTime createdAt;
-        @Schema(description = "마지막 정보 수정 시간")
+        @Schema(description = "마지막 정보 수정 시간", example = "2025-10-01T12:00:00")
         private LocalDateTime lastModifiedAt;
 
         public static UserResponse from(User user) {

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -12,13 +12,18 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Table(name = "USER_ACCOUNT")
+@Table(
+    name = "USER_ACCOUNT",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "USER_NICKNAME", columnNames = "nickname")
+    }
+)
 public class User extends TimeStampedEntity {
     @Id
     @Column(length = 50)
     private String id;
 
-    @Column(nullable=false, length = 50)
+    @Column(nullable=false, length = 60)
     private String password;
 
     @Column(nullable=false, length = 30)

--- a/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
+++ b/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     USER_ALREADY_JOINED(400, "이미 가입된 그룹입니다."),
     USER_NOT_FOUND(404, "존재하지 않는 사용자입니다."),
     USER_PASSWORD_NOT_MATCH(400, "올바른 비밀번호가 아닙니다."),
+    USER_NICKNAME_ALREADY_EXISTS(409, "중복되는 닉네임입니다."),
+    USER_ALREADY_ID_EXISTS(409, "중복되는 아이디입니다."),
 
     // Invite
     INVITE_ALREADY_MEMBER(400, "이미 등록된 멤버입니다."),

--- a/src/main/java/com/depth/learningcrew/system/security/model/JwtDto.java
+++ b/src/main/java/com/depth/learningcrew/system/security/model/JwtDto.java
@@ -1,9 +1,8 @@
 package com.depth.learningcrew.system.security.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -41,5 +40,25 @@ public class JwtDto {
         private LocalDateTime expireAt;
         private String subject;
         private String refreshUuid;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class TokenInfo {
+        private String accessToken;
+        private String refreshToken;
+        private LocalDateTime accessTokenExpiresAt;
+        private LocalDateTime refreshTokenExpiresAt;
+
+        public static TokenInfo of(JwtDto.TokenPair tokenPair) {
+            return TokenInfo.builder()
+                    .accessToken(tokenPair.getAccessToken().getTokenString())
+                    .refreshToken(tokenPair.getRefreshToken().getTokenString())
+                    .accessTokenExpiresAt(tokenPair.getAccessToken().getExpireAt())
+                    .refreshTokenExpiresAt(tokenPair.getRefreshToken().getExpireAt())
+                    .build();
+        }
     }
 }


### PR DESCRIPTION
## 📌 PR 개요 : 

- USER_ACCOUNT table : password 필드 제약을 VARCHAR(50) -> VARCHAR(60)으로 변경 (BCryptPasswordEncoder Issue)
- ⚠️ 로그인 API 요청 형식에서, user는 객체로 묶여있는데 토큰정보만 따로 놀아서 token이란 이름으로 묶어줌
- Jira의 회원 가입 요청/응답의 필드에서 birthday, gender 추가 -> 화면정의서 및 ERD 기반
- 프로필은 추가 안했음 (이유1. Jira에서 언급이 없음, 이유 2. 업로드 기능이 구현되고 추가해도 됨)
- ⚠️ Jira의 요청/응답 부의 PK가 email로 명시됐는데, id로 바꿈 -> 화면정의서의 아이디란 표현(단, 이메일 형식으로 제한), ERD도 id로 정의 
- UserEntity에서, nickname을 UniqueConstrains로 설정함 -> 화면 정의서에서 중복 금지라고 제약둠
- Duplicate Exception 에 대한 GlobalException 정의했음 & ErrorCode 도 적절히 추가하여 화면 정의서의 요구 충족
- Jira에서 요구되지 않았던 /id-exist API 추가함 -> /id-exist는 화면정의서에서의 중복검사 요구사항 때문
- Jira에서 요구되지 않았던 /me API 추가 -> 어차피 유저 정보에 대한 조회는 웬만하면 필요하고, Token 유효성 테스트에도 편리하기 때문
- 그 외 화면 정의서에서 요구한 제약조건들을 Validation으로 적절히 처리하였음 

⏹️ 두 번째(로그인 ..), 다섯 번 째(email->id ...) 항목의 내용은, 의도된 응답형식이었다면 수정해서 다시 PR 올리도록 할 예정 

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [✅ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [✅] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
- https://hooby.notion.site/MVP-Project-Jwt-Auth-Login-SignUp-234f6c063f3e80a99569c9a127e06c80?source=copy_link
