### PR TITLE
LNIT-16-유저-도메인-API-명세에-맞게-수정

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -46,6 +46,13 @@ public class AuthController {
         return authService.checkIdExist(request);
     }
 
+    @GetMapping("/nickname-exist")
+    @Operation(summary = "아이디 중복 확인", description = "입력된 아이디의 사용 가능 여부를 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "아이디 확인 성공")
+    public AuthDto.NicknameExistResponse checkNickname(@RequestBody @Valid AuthDto.NicknameExistRequest request) {
+        return authService.checkNicknameExist(request);
+    }
+
     @PostMapping("/token/refresh")
     @Operation(summary = "토큰 재발행", description = "새로운 Access/Refresh Token을 재발급받습니다.")
     @ApiResponse(responseCode = "200", description = "토큰 재발행 성공")

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -60,16 +60,6 @@ public class AuthController {
         return authService.recreateToken(request);
     }
 
-    @GetMapping("/me")
-    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "내 정보 조회 성공")
-    public UserDto.UserResponse whoami(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        return UserDto.UserResponse.from(userDetails.getUser());
-    }
-
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "현재 사용자의 Refresh Token을 삭제하며 로그아웃 처리합니다.")
     @ApiResponse(

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -47,8 +47,8 @@ public class AuthController {
     }
 
     @GetMapping("/nickname-exist")
-    @Operation(summary = "아이디 중복 확인", description = "입력된 아이디의 사용 가능 여부를 확인합니다.")
-    @ApiResponse(responseCode = "200", description = "아이디 확인 성공")
+    @Operation(summary = "닉네임 중복 확인", description = "입력된 닉네임의 사용 가능 여부를 확인합니다.")
+    @ApiResponse(responseCode = "200", description = "닉네임 확인 성공")
     public AuthDto.NicknameExistResponse checkNickname(@RequestBody @Valid AuthDto.NicknameExistRequest request) {
         return authService.checkNicknameExist(request);
     }

--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.depth.learningcrew.domain.auth.service.AuthService;
 import com.depth.learningcrew.domain.user.dto.UserDto;
 import com.depth.learningcrew.system.security.model.JwtDto;
 import com.depth.learningcrew.system.security.model.UserDetails;
+import com.depth.learningcrew.system.security.utility.validator.ValidatorUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -39,18 +40,20 @@ public class AuthController {
         return authService.signIn(request);
     }
 
-    @GetMapping("/id-exist")
+    @GetMapping("/email-exist")
     @Operation(summary = "아이디 중복 확인", description = "입력된 아이디의 사용 가능 여부를 확인합니다.")
     @ApiResponse(responseCode = "200", description = "아이디 확인 성공")
-    public AuthDto.IdExistResponse checkId(@RequestBody @Valid AuthDto.IdExistRequest request) {
-        return authService.checkIdExist(request);
+    public AuthDto.EmailExistResponse checkEmail(@RequestParam("email") String email) {
+        ValidatorUtil.validateEmail(email);
+        return authService.checkEmailExist(email);
     }
 
     @GetMapping("/nickname-exist")
     @Operation(summary = "닉네임 중복 확인", description = "입력된 닉네임의 사용 가능 여부를 확인합니다.")
     @ApiResponse(responseCode = "200", description = "닉네임 확인 성공")
-    public AuthDto.NicknameExistResponse checkNickname(@RequestBody @Valid AuthDto.NicknameExistRequest request) {
-        return authService.checkNicknameExist(request);
+    public AuthDto.NicknameExistResponse checkNickname(@RequestParam("nickname") String nickname) {
+        ValidatorUtil.validateNickname(nickname);
+        return authService.checkNicknameExist(nickname);
     }
 
     @PostMapping("/token/refresh")

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -41,6 +41,10 @@ public class AuthDto {
         @Schema(description = "사용자 생년월일", example = "2000-01-01")
         private LocalDate birthday;
 
+        // TODO: AttachedFile Entity 구현 이후 주석 해제
+        // @Schema(description = "프로필 이미지 정보")
+        // private AttachedFile profileImage;
+
         @NotNull(message = "성별을 입력해주세요.")
         @Schema(
                 description = "사용자 성별",
@@ -164,8 +168,6 @@ public class AuthDto {
                     .build();
         }
     }
-
-
 
     @Data
     @AllArgsConstructor

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -2,6 +2,7 @@ package com.depth.learningcrew.domain.auth.dto;
 
 import com.depth.learningcrew.domain.user.dto.UserDto;
 import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
 import com.depth.learningcrew.domain.user.entity.User;
 import com.depth.learningcrew.system.security.model.JwtDto;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,6 +57,7 @@ public class AuthDto {
                     .password(encoder.encode(password))
                     .birthday(birthday)
                     .gender(gender)
+                    .role(Role.USER)
                     .build();
         }
     }

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -135,6 +135,38 @@ public class AuthDto {
         }
     }
 
+    // 닉네임 중복 인증 확인 요청 DTO
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "닉네임 중복 확인 요청 DTO")
+    public static class NicknameExistRequest {
+        @NotBlank(message = "확인할 닉네임 (특수문자를 제외한 2~10자리)을 입력해주세요.")
+        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
+        @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
+        private String nickname;
+    }
+
+    // 닉네임 중복 인증 확인 응답 DTO
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Schema(description = "닉네임 중복 확인 응답 DTO")
+    public static class NicknameExistResponse {
+        @Schema(description = "닉네임 존재 여부 (true/false)", example = "false")
+        private boolean isExist;
+
+        public static NicknameExistResponse from(boolean exists) {
+            return NicknameExistResponse.builder()
+                    .isExist(exists)
+                    .build();
+        }
+    }
+
+
+
     @Data
     @AllArgsConstructor
     @NoArgsConstructor

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -24,21 +24,21 @@ public class AuthDto {
     public static class SignUpRequest {
         @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "learnit@mju.ac.kr")
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
         private String id;
 
         @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
+        @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;
 
         @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 비밀번호", example = "newpassword123 || NewPassword123")
+        @Schema(description = "사용자 비밀번호", example = "password content")
         private String password;
 
         @NotNull(message = "생년월일을 입력해주세요.")
-        @Schema(description = "사용자 생년월일", example = "2000-01-01")
+        @Schema(description = "사용자 생년월일", example = "yyyy-mm-dd")
         private LocalDate birthday;
 
         // TODO: AttachedFile Entity 구현 이후 주석 해제
@@ -48,7 +48,7 @@ public class AuthDto {
         @NotNull(message = "성별을 입력해주세요.")
         @Schema(
                 description = "사용자 성별",
-                example = "MALE",
+                example = "MALE | FEMALE | OTHER",
                 allowableValues = {"MALE", "FEMALE", "OTHER"}
         )
         private Gender gender;
@@ -75,12 +75,12 @@ public class AuthDto {
     public static class SignInRequest {
         @NotBlank(message = "이메일을 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "learnit@mju.ac.kr")
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
         private String id;
 
         @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 비밀번호", example = "newpassword123 || NewPassword123")
+        @Schema(description = "사용자 비밀번호", example = "password content")
         private String password;
 
     }
@@ -118,7 +118,7 @@ public class AuthDto {
     public static class IdExistRequest {
         @NotBlank(message = "확인할 아이디(이메일 주소)를 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "확인할 아이디(이메일 주소)", example = "learnit@mju.ac.kr")
+        @Schema(description = "확인할 아이디(이메일 주소)", example = "user@email.com")
         private String id;
     }
 
@@ -148,7 +148,7 @@ public class AuthDto {
     public static class NicknameExistRequest {
         @NotBlank(message = "확인할 닉네임 (특수문자를 제외한 2~10자리)을 입력해주세요.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
+        @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;
     }
 

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -21,9 +21,9 @@ public class AuthDto {
     @Builder
     @Schema(description = "회원가입 요청 DTO")
     public static class SignUpRequest {
-        @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
+        @NotBlank(message = "이메일 형식으로 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
+        @Schema(description = "이메일 (아이디)", example = "user@email.com")
         private String email;
 
         @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
@@ -74,7 +74,7 @@ public class AuthDto {
     public static class SignInRequest {
         @NotBlank(message = "이메일을 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
+        @Schema(description = "이메일(아이디)", example = "user@email.com")
         private String email;
 
         @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
@@ -113,9 +113,9 @@ public class AuthDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    @Schema(description = "아이디 중복 확인 응답 DTO")
+    @Schema(description = "이메일(아이디) 중복 확인 응답 DTO")
     public static class EmailExistResponse {
-        @Schema(description = "아이디 존재 여부 (true/false)", example = "false")
+        @Schema(description = "이메일(아이디) 존재 여부 (true/false)", example = "false")
         private boolean isExist;
 
         public static EmailExistResponse from(boolean exists) {

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -19,7 +19,7 @@ public class AuthDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    @Schema(description = "회원가입 요청 DTO")
+    @Schema(description = "회원가입 요청 DTO", requiredProperties = {"email", "nickname", "password", "birthday", "gender"})
     public static class SignUpRequest {
         @NotBlank(message = "이메일 형식으로 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
@@ -70,7 +70,7 @@ public class AuthDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    @Schema(description = "로그인 요청 DTO")
+    @Schema(description = "로그인 요청 DTO", requiredProperties = {"email", "password"})
     public static class SignInRequest {
         @NotBlank(message = "이메일을 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
@@ -146,10 +146,11 @@ public class AuthDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    @Schema(description = "토큰 재발행 DTO")
+    @Schema(description = "토큰 재발행 DTO", requiredProperties = {"refreshToken"})
     public static class RecreateRequest {
         @NotBlank(message = "Refresh Token을 입력해주세요.")
         @Schema(description = "재발행할 Refresh Token", example = "refreshTokenString")
         private String refreshToken;
     }
 }
+

--- a/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/dto/AuthDto.java
@@ -11,7 +11,6 @@ import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 public class AuthDto {
 
@@ -25,7 +24,7 @@ public class AuthDto {
         @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
-        private String id;
+        private String email;
 
         @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
@@ -56,7 +55,7 @@ public class AuthDto {
 
         public User toEntity(PasswordEncoder encoder) {
             return User.builder()
-                    .id(id)
+                    .email(email)
                     .nickname(nickname)
                     .password(encoder.encode(password))
                     .birthday(birthday)
@@ -76,7 +75,7 @@ public class AuthDto {
         @NotBlank(message = "이메일을 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
-        private String id;
+        private String email;
 
         @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
@@ -109,47 +108,21 @@ public class AuthDto {
         }
     }
 
-    // 아이디 중복 인증 확인 요청 DTO
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    @Schema(description = "아이디 중복 확인 요청 DTO")
-    public static class IdExistRequest {
-        @NotBlank(message = "확인할 아이디(이메일 주소)를 입력해주세요.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "확인할 아이디(이메일 주소)", example = "user@email.com")
-        private String id;
-    }
-
     // 아이디 중복 인증 확인 응답 DTO
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
     @Schema(description = "아이디 중복 확인 응답 DTO")
-    public static class IdExistResponse {
+    public static class EmailExistResponse {
         @Schema(description = "아이디 존재 여부 (true/false)", example = "false")
         private boolean isExist;
 
-        public static IdExistResponse from(boolean exists) {
-            return IdExistResponse.builder()
+        public static EmailExistResponse from(boolean exists) {
+            return EmailExistResponse.builder()
                     .isExist(exists)
                     .build();
         }
-    }
-
-    // 닉네임 중복 인증 확인 요청 DTO
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    @Schema(description = "닉네임 중복 확인 요청 DTO")
-    public static class NicknameExistRequest {
-        @NotBlank(message = "확인할 닉네임 (특수문자를 제외한 2~10자리)을 입력해주세요.")
-        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 닉네임", example = "user nickname")
-        private String nickname;
     }
 
     // 닉네임 중복 인증 확인 응답 DTO

--- a/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
@@ -11,22 +11,16 @@ import com.depth.learningcrew.domain.user.entity.User;
 import com.depth.learningcrew.domain.user.repository.UserRepository;
 import com.depth.learningcrew.system.exception.model.ErrorCode;
 import com.depth.learningcrew.system.exception.model.RestException;
-import com.depth.learningcrew.system.security.exception.JwtBlacklistedTokenException;
 import com.depth.learningcrew.system.security.model.JwtDto;
 import com.depth.learningcrew.system.security.model.UserDetails;
 import com.depth.learningcrew.system.security.service.UserLoadService;
 import com.depth.learningcrew.system.security.utility.jwt.JwtTokenProvider;
 import com.depth.learningcrew.system.security.utility.jwt.JwtTokenResolver;
-import com.depth.learningcrew.system.security.utility.jwt.TokenType;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -68,9 +62,9 @@ public class AuthService {
 
     @Transactional
     public UserDto.UserResponse signUp(AuthDto.SignUpRequest request) {
-        boolean isExisting = userRepository.existsById(request.getId());
+        boolean isExisting = userRepository.existsByEmail(request.getEmail());
         if(isExisting)
-            throw new RestException(ErrorCode.USER_ALREADY_ID_EXISTS);
+            throw new RestException(ErrorCode.USER_ALREADY_EMAIL_EXISTS);
 
         User toSave = request.toEntity(passwordEncoder);
         User saved = userRepository.save(toSave);
@@ -80,7 +74,7 @@ public class AuthService {
 
     @Transactional
     public AuthDto.SignInResponse signIn(AuthDto.SignInRequest request) {
-        var found = userRepository.findById(request.getId())
+        var found = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
 
         if(!passwordEncoder.matches(request.getPassword(), found.getPassword()))
@@ -104,14 +98,14 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public AuthDto.IdExistResponse checkIdExist(AuthDto.IdExistRequest request) {
-        boolean exists = userRepository.existsById(request.getId());
-        return AuthDto.IdExistResponse.from(exists);
+    public AuthDto.EmailExistResponse checkEmailExist(String email) {
+        boolean exists = userRepository.existsByEmail(email);
+        return AuthDto.EmailExistResponse.from(exists);
     }
 
     @Transactional(readOnly = true)
-    public AuthDto.NicknameExistResponse checkNicknameExist(AuthDto.NicknameExistRequest request) {
-        boolean exists = userRepository.existsByNickname(request.getNickname());
+    public AuthDto.NicknameExistResponse checkNicknameExist(String nickname) {
+        boolean exists = userRepository.existsByNickname(nickname);
         return AuthDto.NicknameExistResponse.from(exists);
     }
 

--- a/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/service/AuthService.java
@@ -109,6 +109,12 @@ public class AuthService {
         return AuthDto.IdExistResponse.from(exists);
     }
 
+    @Transactional(readOnly = true)
+    public AuthDto.NicknameExistResponse checkNicknameExist(AuthDto.NicknameExistRequest request) {
+        boolean exists = userRepository.existsByNickname(request.getNickname());
+        return AuthDto.NicknameExistResponse.from(exists);
+    }
+
     @Transactional
     public void logout(UserDetails userDetails, HttpServletRequest request) {
         String accessToken = getAccessTokenFromRequest(request);

--- a/src/main/java/com/depth/learningcrew/domain/user/controller/UserController.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/controller/UserController.java
@@ -1,0 +1,43 @@
+package com.depth.learningcrew.domain.user.controller;
+
+import com.depth.learningcrew.domain.user.dto.UserDto;
+import com.depth.learningcrew.domain.user.service.UserService;
+import com.depth.learningcrew.system.security.model.UserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@Tag(name = "User", description = "사용자 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "내 정보 조회 성공")
+    public UserDto.UserResponse whoami(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        return UserDto.UserResponse.from(userDetails.getUser());
+    }
+
+    @PatchMapping("/me")
+    @Operation(summary = "내 정보 수정", description = "현재 로그인된 사용자의 정보를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "내 정보 수정 성공")
+    public UserDto.UserUpdateResponse update(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody UserDto.UserUpdateRequest request
+    ) {
+        return userService.update(userDetails.getUser(), request);
+    }
+}

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -51,25 +51,24 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserUpdateRequest {
-        @NotBlank(message = "이메일 형식으로 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "이메일(아이디)", example = "user@email.com")
+        @Schema(description = "이메일(아이디) (선택사항, 필수X)", example = "user@email.com")
         private String email;
 
-        @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 닉네임", example = "user nickname")
+        @Schema(description = "사용자 닉네임 (선택사항, 필수X)", example = "user nickname")
         private String nickname;
 
-        @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 비밀번호", example = "password content")
+        @Schema(description = "사용자 비밀번호 (선택사항, 필수X)", example = "password content")
         private String password;
 
         // TODO: ProfileImage는 AttachedFile Entity 구현 이후 추후 다룸
 
         public void applyTo(User user, PasswordEncoder encoder) {
-            user.update(this, encoder);
+            if (email != null && !email.equals(user.getEmail())) {user.changeEmail(email);}
+            if (nickname != null && !nickname.equals(user.getNickname())) {user.changeNickname(nickname);}
+            if (password != null) {user.changePassword(password, encoder);}
         }
     }
 

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -4,10 +4,14 @@ import com.depth.learningcrew.domain.user.entity.Gender;
 import com.depth.learningcrew.domain.user.entity.Role;
 import com.depth.learningcrew.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 
@@ -36,6 +40,63 @@ public class UserDto {
                     .nickname(user.getNickname())
                     .role(user.getRole())
                     .gender(user.getGender())
+                    .createdAt(user.getCreatedAt())
+                    .lastModifiedAt(user.getLastModifiedAt())
+                    .build();
+        }
+    }
+
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class UserUpdateRequest {
+        @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
+        private String id;
+
+        @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
+        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
+        @Schema(description = "사용자 닉네임", example = "user nickname")
+        private String nickname;
+
+        @NotBlank(message = "대소문자 영문자와 숫자를 포함한 8자리 이상의 비밀번호를 입력해주세요.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
+        @Schema(description = "사용자 비밀번호", example = "password content")
+        private String password;
+
+        // TODO: ProfileImage는 AttachedFile Entity 구현 이후 추후 다룸
+
+        public void applyTo(User user, PasswordEncoder encoder) {
+            user.updateNickname(nickname);
+            if (password != null && !password.isBlank()) {
+                user.updatePassword(encoder.encode(password));
+            }
+        }
+    }
+
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class UserUpdateResponse {
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@example.com")
+        private String id;
+        @Schema(description = "사용자 닉네임", example = "user nickname")
+        private String nickname;
+        @Schema(description = "사용자 역할", example = "USER | ADMIN")
+        private Role role;
+        @Schema(description = "계정 생성 시간", example = "ISO Datetime")
+        private LocalDateTime createdAt;
+        @Schema(description = "마지막 정보 수정 시간", example = "ISO Datetime")
+        private LocalDateTime lastModifiedAt;
+
+        public static UserUpdateResponse from(User user) {
+            return UserUpdateResponse.builder()
+                    .id(user.getId())
+                    .nickname(user.getNickname())
+                    .role(user.getRole())
                     .createdAt(user.getCreatedAt())
                     .lastModifiedAt(user.getLastModifiedAt())
                     .build();

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -1,5 +1,7 @@
 package com.depth.learningcrew.domain.user.dto;
 
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
 import com.depth.learningcrew.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -19,6 +21,10 @@ public class UserDto {
         private String id;
         @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
         private String nickname;
+        @Schema(description = "사용자 역할", example = "USER | ADMIN")
+        private Role role;
+        @Schema(description = "사용자 성별", example = "MALE | FEMAIL | OTHER")
+        private Gender gender;
         @Schema(description = "계정 생성 시간", example = "2025-10-01T12:00:00")
         private LocalDateTime createdAt;
         @Schema(description = "마지막 정보 수정 시간", example = "2025-10-01T12:00:00")
@@ -28,6 +34,8 @@ public class UserDto {
             return UserResponse.builder()
                     .id(user.getId())
                     .nickname(user.getNickname())
+                    .role(user.getRole())
+                    .gender(user.getGender())
                     .createdAt(user.getCreatedAt())
                     .lastModifiedAt(user.getLastModifiedAt())
                     .build();

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -51,11 +51,6 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserUpdateRequest {
-        @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
-        private String id;
-
         @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
         @Schema(description = "사용자 닉네임", example = "user nickname")

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -21,7 +21,7 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserResponse {
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
+        @Schema(description = "이메일(아이디)", example = "user@email.com")
         private String email;
         @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;
@@ -51,9 +51,9 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserUpdateRequest {
-        @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
+        @NotBlank(message = "이메일 형식으로 입력해주세요.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
+        @Schema(description = "이메일(아이디)", example = "user@email.com")
         private String email;
 
         @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
@@ -78,7 +78,7 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserUpdateResponse {
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@example.com")
+        @Schema(description = "이메일(아이디)", example = "user@example.com")
         private String email;
         @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -52,23 +52,23 @@ public class UserDto {
     @Getter
     public static class UserUpdateRequest {
         @Email(message = "올바른 이메일 형식이 아닙니다.")
-        @Schema(description = "이메일(아이디) (선택사항, 필수X)", example = "user@email.com")
+        @Schema(description = "이메일(아이디)", example = "user@email.com")
         private String email;
 
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 닉네임 (선택사항, 필수X)", example = "user nickname")
+        @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;
 
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,}", message = "비밀번호 조건에 충족되지 않습니다.")
-        @Schema(description = "사용자 비밀번호 (선택사항, 필수X)", example = "password content")
+        @Schema(description = "사용자 비밀번호", example = "password content")
         private String password;
 
         // TODO: ProfileImage는 AttachedFile Entity 구현 이후 추후 다룸
 
         public void applyTo(User user, PasswordEncoder encoder) {
-            if (email != null && !email.equals(user.getEmail())) {user.changeEmail(email);}
-            if (nickname != null && !nickname.equals(user.getNickname())) {user.changeNickname(nickname);}
-            if (password != null) {user.changePassword(password, encoder);}
+            if (email != null && !email.equals(user.getEmail())) {user.setEmail(email);}
+            if (nickname != null && !nickname.equals(user.getNickname())) {user.setNickname(nickname);}
+            if (password != null) {user.setPassword(encoder.encode(password));}
         }
     }
 

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -17,17 +17,17 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserResponse {
-        @Schema(description = "사용자 아이디(이메일 형식)", example = "learnit@mju.ac.kr")
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
         private String id;
-        @Schema(description = "사용자 닉네임", example = "LearnIt팀1")
+        @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;
-        @Schema(description = "사용자 역할", example = "USER | ADMIN")
+        @Schema(description = "사용자 역할", example = "USER")
         private Role role;
         @Schema(description = "사용자 성별", example = "MALE | FEMAIL | OTHER")
         private Gender gender;
-        @Schema(description = "계정 생성 시간", example = "2025-10-01T12:00:00")
+        @Schema(description = "계정 생성 시간", example = "ISO Datetime")
         private LocalDateTime createdAt;
-        @Schema(description = "마지막 정보 수정 시간", example = "2025-10-01T12:00:00")
+        @Schema(description = "마지막 정보 수정 시간", example = "ISO Datetime")
         private LocalDateTime lastModifiedAt;
 
         public static UserResponse from(User user) {

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -22,7 +22,7 @@ public class UserDto {
     @Getter
     public static class UserResponse {
         @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
-        private String id;
+        private String email;
         @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;
         @Schema(description = "사용자 역할", example = "USER")
@@ -36,7 +36,7 @@ public class UserDto {
 
         public static UserResponse from(User user) {
             return UserResponse.builder()
-                    .id(user.getId())
+                    .email(user.getEmail())
                     .nickname(user.getNickname())
                     .role(user.getRole())
                     .gender(user.getGender())
@@ -51,6 +51,11 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserUpdateRequest {
+        @NotBlank(message = "아이디를 이메일 형식으로 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "사용자 아이디(이메일 형식)", example = "user@email.com")
+        private String email;
+
         @NotBlank(message = "특수문자를 제외한 2~10자리의 닉네임을 입력해주세요.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임 조건에 충족되지 않습니다.")
         @Schema(description = "사용자 닉네임", example = "user nickname")
@@ -64,10 +69,7 @@ public class UserDto {
         // TODO: ProfileImage는 AttachedFile Entity 구현 이후 추후 다룸
 
         public void applyTo(User user, PasswordEncoder encoder) {
-            user.updateNickname(nickname);
-            if (password != null && !password.isBlank()) {
-                user.updatePassword(encoder.encode(password));
-            }
+            user.update(this, encoder);
         }
     }
 
@@ -77,7 +79,7 @@ public class UserDto {
     @Getter
     public static class UserUpdateResponse {
         @Schema(description = "사용자 아이디(이메일 형식)", example = "user@example.com")
-        private String id;
+        private String email;
         @Schema(description = "사용자 닉네임", example = "user nickname")
         private String nickname;
         @Schema(description = "사용자 역할", example = "USER | ADMIN")
@@ -89,7 +91,7 @@ public class UserDto {
 
         public static UserUpdateResponse from(User user) {
             return UserUpdateResponse.builder()
-                    .id(user.getId())
+                    .email(user.getEmail())
                     .nickname(user.getNickname())
                     .role(user.getRole())
                     .createdAt(user.getCreatedAt())

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/Role.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.depth.learningcrew.domain.user.entity;
+
+public enum Role {
+    USER, ADMIN;
+}

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -14,15 +14,16 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 @Table(
     name = "USER_ACCOUNT",
     uniqueConstraints = {
-        @UniqueConstraint(name = "USER_NICKNAME", columnNames = "nickname"),
-        @UniqueConstraint(name = "USER_EMAIL", columnNames = "email")
+            @UniqueConstraint(name = "USER_NICKNAME", columnNames = "nickname"),
+            @UniqueConstraint(name = "USER_EMAIL", columnNames = "email")
     }
 )
 public class User extends TimeStampedEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Setter(AccessLevel.NONE)
     private Integer id;
 
     @Column(nullable=false, length = 50)
@@ -48,9 +49,5 @@ public class User extends TimeStampedEntity {
     private Role role = Role.USER;
 
     // TODO: AttachedFile Entity 구현 이후 연관관계 매핑 적용
-
-    public void changeNickname(String nickname) { this.nickname = nickname; }
-    public void changeEmail(String email) { this.email = email; }
-    public void changePassword(String password, PasswordEncoder encoder) { this.password = encoder.encode(password); }
 
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -1,9 +1,11 @@
 package com.depth.learningcrew.domain.user.entity;
 
 import com.depth.learningcrew.common.auditor.TimeStampedEntity;
+import com.depth.learningcrew.domain.user.dto.UserDto;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
 
@@ -15,18 +17,22 @@ import java.time.LocalDate;
 @Table(
     name = "USER_ACCOUNT",
     uniqueConstraints = {
-        @UniqueConstraint(name = "USER_NICKNAME", columnNames = "nickname")
+        @UniqueConstraint(name = "USER_NICKNAME", columnNames = "nickname"),
+        @UniqueConstraint(name = "USER_EMAIL", columnNames = "email")
     }
 )
 public class User extends TimeStampedEntity {
-    @Id
-    @Column(length = 50)
-    private String id;
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable=false, length = 50)
+    private String email;
 
     @Column(nullable=false, length = 60)
     private String password;
 
-    @Column(nullable=false, length = 30)
+    // 대소문자 구분해서 저장하도록 COLLATE 설정 (단, 이는 MySQL, MariaDB에서 가능)(ex. Hooby <-> hooby)
+    @Column(nullable=false, length = 30, columnDefinition = "VARCHAR(30) COLLATE utf8mb4_bin")
     private String nickname;
 
     @Column(nullable=false)
@@ -42,11 +48,11 @@ public class User extends TimeStampedEntity {
 
     // TODO: AttachedFile Entity 구현 이후 연관관계 매핑 적용
 
-    public void updateNickname(String nickname) {
-        this.nickname = nickname;
-    }
+    public void update(UserDto.UserUpdateRequest request, PasswordEncoder encoder) {
+        if (!this.email.equals(request.getEmail())) {this.email = request.getEmail();}
 
-    public void updatePassword(String encodedPassword) {
-        this.password = encodedPassword;
+        if (!this.nickname.equals(request.getNickname())) {this.nickname = request.getNickname();}
+
+        this.password = encoder.encode(request.getPassword());
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -39,4 +39,6 @@ public class User extends TimeStampedEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable=false, length = 20)
     private Role role = Role.USER;
+
+    // TODO: AttachedFile Entity 구현 이후 연관관계 매핑 적용
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -49,11 +49,8 @@ public class User extends TimeStampedEntity {
 
     // TODO: AttachedFile Entity 구현 이후 연관관계 매핑 적용
 
-    public void update(UserDto.UserUpdateRequest request, PasswordEncoder encoder) {
-        if (!this.email.equals(request.getEmail())) {this.email = request.getEmail();}
+    public void changeNickname(String nickname) { this.nickname = nickname; }
+    public void changeEmail(String email) { this.email = email; }
+    public void changePassword(String password, PasswordEncoder encoder) { this.password = encoder.encode(password); }
 
-        if (!this.nickname.equals(request.getNickname())) {this.nickname = request.getNickname();}
-
-        this.password = encoder.encode(request.getPassword());
-    }
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -41,4 +41,12 @@ public class User extends TimeStampedEntity {
     private Role role = Role.USER;
 
     // TODO: AttachedFile Entity 구현 이후 연관관계 매핑 적용
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -44,6 +44,7 @@ public class User extends TimeStampedEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable=false, length = 20)
+    @Builder.Default
     private Role role = Role.USER;
 
     // TODO: AttachedFile Entity 구현 이후 연관관계 매핑 적용

--- a/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/entity/User.java
@@ -35,4 +35,8 @@ public class User extends TimeStampedEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable=false, length = 20)
     private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable=false, length = 20)
+    private Role role = Role.USER;
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/repository/UserRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
-    Optional<User> findById(String id);
-
-    boolean existsById(String id);
+    Optional<User> findByEmail(String Email);
+    Optional<User> findByNickname(String nickname);
+    Optional<User> findById(Integer id);
+    boolean existsByEmail(String id);
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findById(String id);
 
     boolean existsById(String id);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/service/UserService.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/service/UserService.java
@@ -20,12 +20,20 @@ public class UserService {
     @Transactional
     public UserDto.UserUpdateResponse update(User user, UserDto.UserUpdateRequest request) {
 
-        if (!user.getNickname().equals(request.getNickname())
+        User found = userRepository.findById(user.getId())
+                .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+        if (!found.getNickname().equals(request.getNickname())
                 && userRepository.existsByNickname(request.getNickname())) {
             throw new RestException(ErrorCode.USER_NICKNAME_ALREADY_EXISTS);
         }
 
-        request.applyTo(user, passwordEncoder);
-        return UserDto.UserUpdateResponse.from(user);
+        if (!found.getEmail().equals(request.getEmail())
+                && userRepository.existsByEmail(request.getEmail())) {
+            throw new RestException(ErrorCode.USER_ALREADY_EMAIL_EXISTS);
+        }
+
+        request.applyTo(found, passwordEncoder);
+        return UserDto.UserUpdateResponse.from(found);
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/service/UserService.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/service/UserService.java
@@ -1,0 +1,31 @@
+package com.depth.learningcrew.domain.user.service;
+
+import com.depth.learningcrew.domain.user.dto.UserDto;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.domain.user.repository.UserRepository;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public UserDto.UserUpdateResponse update(User user, UserDto.UserUpdateRequest request) {
+
+        if (!user.getNickname().equals(request.getNickname())
+                && userRepository.existsByNickname(request.getNickname())) {
+            throw new RestException(ErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+        }
+
+        request.applyTo(user, passwordEncoder);
+        return UserDto.UserUpdateResponse.from(user);
+    }
+}

--- a/src/main/java/com/depth/learningcrew/domain/user/service/UserService.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/service/UserService.java
@@ -23,13 +23,15 @@ public class UserService {
         User found = userRepository.findById(user.getId())
                 .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
 
-        if (!found.getNickname().equals(request.getNickname())
-                && userRepository.existsByNickname(request.getNickname())) {
+        if (request.getNickname() != null &&
+                !found.getNickname().equals(request.getNickname()) &&
+                userRepository.existsByNickname(request.getNickname())) {
             throw new RestException(ErrorCode.USER_NICKNAME_ALREADY_EXISTS);
         }
 
-        if (!found.getEmail().equals(request.getEmail())
-                && userRepository.existsByEmail(request.getEmail())) {
+        if (request.getEmail() != null &&
+                !found.getEmail().equals(request.getEmail()) &&
+                userRepository.existsByEmail(request.getEmail())) {
             throw new RestException(ErrorCode.USER_ALREADY_EMAIL_EXISTS);
         }
 

--- a/src/main/java/com/depth/learningcrew/system/configuration/cache/CacheNames.java
+++ b/src/main/java/com/depth/learningcrew/system/configuration/cache/CacheNames.java
@@ -3,5 +3,5 @@ package com.depth.learningcrew.system.configuration.cache;
 public final class CacheNames {
     private CacheNames() {}
 
-    public static final String REFRESH_TOKEN_UUID = "refreshTokenUuid";
+    public static final String REFRESH_TOKEN_UUID = "refresh-token-uuid";
 }

--- a/src/main/java/com/depth/learningcrew/system/configuration/cache/CacheProperties.java
+++ b/src/main/java/com/depth/learningcrew/system/configuration/cache/CacheProperties.java
@@ -11,7 +11,7 @@ import java.util.Map;
 @Getter
 @Setter
 @Component
-@ConfigurationProperties(prefix = "cache.specs")
+@ConfigurationProperties(prefix = "cache")
 public class CacheProperties {
 
     private Map<String, Spec> specs = new HashMap<>();

--- a/src/main/java/com/depth/learningcrew/system/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/depth/learningcrew/system/configuration/security/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                     it.excludePath("/api/auth/register");
                     it.excludePath("/api/auth/login");
                     it.excludePath("/api/auth/id-exist");
+                    it.excludePath("/api/auth/nickname-exist");
                     it.excludePath("/api/auth/token/refresh");
                 })
                 .configure(httpSecurity);

--- a/src/main/java/com/depth/learningcrew/system/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/depth/learningcrew/system/configuration/security/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                     it.includePath("/api/**");
                     it.excludePath("/api/auth/register");
                     it.excludePath("/api/auth/login");
-                    it.excludePath("/api/auth/id-exist");
+                    it.excludePath("/api/auth/email-exist");
                     it.excludePath("/api/auth/nickname-exist");
                     it.excludePath("/api/auth/token/refresh");
                 })

--- a/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
+++ b/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(404, "존재하지 않는 사용자입니다."),
     USER_PASSWORD_NOT_MATCH(400, "올바른 비밀번호가 아닙니다."),
     USER_NICKNAME_ALREADY_EXISTS(409, "중복되는 닉네임입니다."),
-    USER_ALREADY_ID_EXISTS(409, "중복되는 아이디입니다."),
+    USER_ALREADY_EMAIL_EXISTS(409, "중복되는 아이디입니다."),
 
     // Invite
     INVITE_ALREADY_MEMBER(400, "이미 등록된 멤버입니다."),

--- a/src/main/java/com/depth/learningcrew/system/security/model/JwtDto.java
+++ b/src/main/java/com/depth/learningcrew/system/security/model/JwtDto.java
@@ -47,9 +47,13 @@ public class JwtDto {
     @NoArgsConstructor
     @Builder
     public static class TokenInfo {
+        @Schema(description = "Access Token", example = "accessTokenContent")
         private String accessToken;
+        @Schema(description = "Refresh Token", example = "refreshTokenContent")
         private String refreshToken;
+        @Schema(description = "Access Token 만료 시간", example = "ISO DateTime")
         private LocalDateTime accessTokenExpiresAt;
+        @Schema(description = "Refresh Token 만료 시간", example = "ISO DateTime")
         private LocalDateTime refreshTokenExpiresAt;
 
         public static TokenInfo of(JwtDto.TokenPair tokenPair) {

--- a/src/main/java/com/depth/learningcrew/system/security/model/UserDetails.java
+++ b/src/main/java/com/depth/learningcrew/system/security/model/UserDetails.java
@@ -17,9 +17,7 @@ public class UserDetails extends AuthDetails{
     private final User user;
 
     @Override
-    public String getKey() {
-        return user.getId();
-    }
+    public String getKey() { return String.valueOf(user.getId());}
 
     public static UserDetails from(User user) {
         User unproxied = Hibernate.unproxy(user, User.class);

--- a/src/main/java/com/depth/learningcrew/system/security/service/UserLoadServiceImpl.java
+++ b/src/main/java/com/depth/learningcrew/system/security/service/UserLoadServiceImpl.java
@@ -16,7 +16,7 @@ public class UserLoadServiceImpl implements UserLoadService {
 
     @Override
     public Optional<UserDetails> loadUserByKey(String key) {
-        return userRepository.findById(key)
+        return userRepository.findById(Integer.parseInt(key))
                 .map(UserDetails::from);
     }
 }

--- a/src/main/java/com/depth/learningcrew/system/security/utility/validator/ValidatorUtil.java
+++ b/src/main/java/com/depth/learningcrew/system/security/utility/validator/ValidatorUtil.java
@@ -1,0 +1,29 @@
+package com.depth.learningcrew.system.security.utility.validator;
+
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import org.springframework.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+public class ValidatorUtil {
+    public static void validateEmail(String email) {
+        if (!StringUtils.hasText(email)) {
+            throw new RestException(ErrorCode.GLOBAL_INVALID_PARAMETER, "이메일은 필수입니다.");
+        }
+
+        if (!Pattern.matches("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$", email)) {
+            throw new RestException(ErrorCode.GLOBAL_INVALID_PARAMETER, "이메일 형식이 올바르지 않습니다.");
+        }
+    }
+
+    public static void validateNickname(String nickname) {
+        if (!StringUtils.hasText(nickname)) {
+            throw new RestException(ErrorCode.GLOBAL_INVALID_PARAMETER, "닉네임은 필수입니다.");
+        }
+
+        if (!Pattern.matches("^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", nickname)) {
+            throw new RestException(ErrorCode.GLOBAL_INVALID_PARAMETER, "닉네임 조건에 부합하지 않습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 개요

- API 명세에 따라 auth/me -> users/me 로 API 변경
- Swagger Example 일부 API 명세에 맞게 수정 (id 부분은 email형식으로)
- API 명세에 따라 기존 Auth API 의 요청/응답 필드 수 추가
- User Domain API (GET users/me, PATCH users/me) 구현
- UserUpdateRequest 부분에서, API 명세의 request 부분 id 필드는 제거 (pk는 수정X)
- TODO: AttachedFile Domain 구현 완료되면, DTO와 Entity 연관관계 매핑해야함
- 회원정보 업데이트 시, 기존의 본인 닉네임과 동일한 경우는 통과 (비밀번호만 바꾸고 싶은 경우 고려)
- 회의 이후 요구조건 수정에 따라 PK를 Seq Id 로 설정했고, 기존 id를 email로 바꾸고 명목 key로 사용
- User Entity에 DB COLLATE utf8mb4_bin 설정 
	- MySQL, MariaDB는 대소문자를 구분하지 않음
	- 하지만 hooby와 Hooby, hoOBy 는 다르다. 따라서 대소문자 가능하도록 설정을 적용했다. 
	- 이렇게 안하면 위 3개의 예시를 같은것으로 인식한다. 
- Cache Key Name을 application-remote.yml에 맞게 변경했다. 
	- 자동 Camel Case로 바인딩될 것을 기대했으나, Map에서 Key에는 그대로 들어감 
	- 물론 Cache 관련 Spec을 동적으로 추가할 일이 MVP에선 없긴해서 Map 빼는 구조로 가도 됨
	- 근데 Map을 빼는 것보다 그냥 CacheNames Class에서 이름 하나 바꾸면 해결되서 이거로 감
- 업데이트 할때는 생일, 성별 이런게 변할 일은 없고 명세에도 해당 필드는 없으므로 기존 명세에 email 필드만 추가
- test 완료

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [✅] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [✅] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 중간에 만났던 문제

- @AuthenticationPrincipal UserDetails userDetails 이거로 유저 정보 가져옴
	- update 실행 -> DB 업데이트 안됨
	- 원인은 이렇게 가져오면 영속성 컨텍스트에 등록이 안되서 그런것

- API 호출자 관점에선 email이 PK이기 때문에 userId를 요청하는것은 비논리적인 구조이다. 
	- 그대로 userDetails를 가져와서 found = userRepository.findById 적용
	- 그러면 영속성 컨텍스트 적용됨 -> 이제 여기서부터 email 사용해서 쓰면 모든 요구 충족

## 🔗 참고 사항

- 닉네임이 중복되면 안되는 이유에 대해 알아보기 -> 완료 (하단 노션 사이트 참조)
- https://hooby.notion.site/Database-Modeling-239f6c063f3e80249f6ed39775ad93c7?source=copy_link
