### PR TITLE
LNIT-20-카테고리-목록-조회-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/GroupCategoryController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/GroupCategoryController.java
@@ -2,6 +2,8 @@ package com.depth.learningcrew.domain.studygroup.controller;
 
 import com.depth.learningcrew.domain.studygroup.dto.GroupCategoryDto;
 import com.depth.learningcrew.domain.studygroup.service.GroupCategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,8 @@ public class GroupCategoryController {
     private final GroupCategoryService groupCategoryService;
 
     @GetMapping
+    @Operation(summary = "카테고리 목록 조회", description = "카테고리 목록 전체를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "카테고리 목록 조회 성공")
     public List<GroupCategoryDto.GroupCategoryResponse> getGroupCategories() {
         return groupCategoryService.getGroupCategories();
     }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/GroupCategoryController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/GroupCategoryController.java
@@ -1,0 +1,23 @@
+package com.depth.learningcrew.domain.studygroup.controller;
+
+import com.depth.learningcrew.domain.studygroup.dto.GroupCategoryDto;
+import com.depth.learningcrew.domain.studygroup.service.GroupCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-groups/categories")
+public class GroupCategoryController {
+
+    private final GroupCategoryService groupCategoryService;
+
+    @GetMapping
+    public List<GroupCategoryDto.GroupCategoryResponse> getGroupCategories() {
+        return groupCategoryService.getGroupCategories();
+    }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/GroupCategoryDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/GroupCategoryDto.java
@@ -1,6 +1,7 @@
 package com.depth.learningcrew.domain.studygroup.dto;
 
 import com.depth.learningcrew.domain.studygroup.entity.GroupCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,9 @@ public class GroupCategoryDto {
     @AllArgsConstructor
     @Getter
     public static class GroupCategoryResponse {
+        @Schema(description = "그룹 카테고리 ID", example = "1")
         private Integer id;
+        @Schema(description = "그룹 카테고리명", example = "언어")
         private String name;
 
         public static GroupCategoryResponse from(GroupCategory groupCategory) {

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/GroupCategoryDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/GroupCategoryDto.java
@@ -1,0 +1,26 @@
+package com.depth.learningcrew.domain.studygroup.dto;
+
+import com.depth.learningcrew.domain.studygroup.entity.GroupCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class GroupCategoryDto {
+
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class GroupCategoryResponse {
+        private Integer id;
+        private String name;
+
+        public static GroupCategoryResponse from(GroupCategory groupCategory) {
+            return GroupCategoryResponse.builder()
+                    .id(groupCategory.getId())
+                    .name(groupCategory.getName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/service/GroupCategoryService.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/service/GroupCategoryService.java
@@ -1,0 +1,26 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import com.depth.learningcrew.domain.studygroup.dto.GroupCategoryDto;
+import com.depth.learningcrew.domain.studygroup.entity.GroupCategory;
+import com.depth.learningcrew.domain.studygroup.repository.GroupCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GroupCategoryService {
+
+    private final GroupCategoryRepository groupCategoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<GroupCategoryDto.GroupCategoryResponse> getGroupCategory() {
+        List<GroupCategory> groupCategories = groupCategoryRepository.findAll();
+        return groupCategories.stream()
+                .map(GroupCategoryDto.GroupCategoryResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/service/GroupCategoryService.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/service/GroupCategoryService.java
@@ -17,7 +17,7 @@ public class GroupCategoryService {
     private final GroupCategoryRepository groupCategoryRepository;
 
     @Transactional(readOnly = true)
-    public List<GroupCategoryDto.GroupCategoryResponse> getGroupCategory() {
+    public List<GroupCategoryDto.GroupCategoryResponse> getGroupCategories() {
         List<GroupCategory> groupCategories = groupCategoryRepository.findAll();
         return groupCategories.stream()
                 .map(GroupCategoryDto.GroupCategoryResponse::from)


### PR DESCRIPTION
## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

디버깅&개발 용도로 사용될 카테고리 목록 전체 조회 API.
DB에 저장된 카테고리 목록을 List 형태로 출력합니다.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [x] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [x] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.

카테고리를 입력하는 API를 개발하지 않은 상태라 Test 코드로 테스트 진행했습니다.
JWT 인가 여부는 PostMan으로 테스트 완료했고, 잘 작동됨을 확인했습니다.
테스트 코드를 이용해 임의의 카테고리 3개를 넣은 후 테스트 진행한 결과 캡쳐본 남깁니다.
<img width="1011" height="280" alt="스크린샷 2025-07-29 201517" src="https://github.com/user-attachments/assets/c6c2f4e8-21e0-41b5-b700-689c298e40cf" />
