### PR TITLE
LNIT-33-스터디-그룹-가입-신청-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
@@ -1,0 +1,36 @@
+package com.depth.learningcrew.domain.studygroup.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
+import com.depth.learningcrew.domain.studygroup.service.StudyGroupApplicationService;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-groups")
+@Tag(name = "Study Group Application", description = "스터디 그룹 가입 신청 API")
+public class StudyGroupApplicationController {
+
+  private final StudyGroupApplicationService studyGroupApplicationService;
+
+  @PostMapping("/{groupId}/join")
+  @Operation(summary = "스터디 그룹 가입 신청", description = "로그인한 사용자가 특정 스터디 그룹에 가입 신청을 합니다.")
+  public ResponseEntity<ApplicationDto.ApplicationResponse> joinStudyGroup(
+      @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.joinStudyGroup(groupId, userDetails);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/ApplicationDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/ApplicationDto.java
@@ -1,0 +1,48 @@
+package com.depth.learningcrew.domain.studygroup.dto;
+
+import java.time.LocalDateTime;
+
+import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.domain.studygroup.entity.State;
+import com.depth.learningcrew.domain.user.dto.UserDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ApplicationDto {
+
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Getter
+  @Schema(description = "스터디 그룹 가입 신청 응답")
+  public static class ApplicationResponse {
+    @Schema(description = "신청자 정보")
+    private UserDto.UserResponse user;
+
+    @Schema(description = "스터디 그룹 정보")
+    private StudyGroupDto.StudyGroupResponse studyGroup;
+
+    @Schema(description = "생성 시간", example = "2024-01-01T00:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "마지막 수정 시간", example = "2024-01-01T00:00:00")
+    private LocalDateTime lastModifiedAt;
+
+    @Schema(description = "신청 상태", example = "PENDING", allowableValues = { "PENDING", "APPROVED", "REJECTED" })
+    private State state;
+
+    public static ApplicationResponse from(Application application) {
+      return ApplicationResponse.builder()
+          .user(UserDto.UserResponse.from(application.getId().getUser()))
+          .studyGroup(StudyGroupDto.StudyGroupResponse.from(application.getId().getStudyGroup(), false))
+          .createdAt(application.getCreatedAt())
+          .lastModifiedAt(application.getLastModifiedAt())
+          .state(application.getState())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/GroupCategory.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/GroupCategory.java
@@ -1,15 +1,24 @@
 package com.depth.learningcrew.domain.studygroup.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class GroupCategory {
 
     @Id
@@ -20,5 +29,6 @@ public class GroupCategory {
     private String name;
 
     @ManyToMany(mappedBy = "categories")
+    @Builder.Default
     private List<StudyGroup> studyGroups = new ArrayList<>();
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyGroup.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyGroup.java
@@ -1,6 +1,7 @@
 package com.depth.learningcrew.domain.studygroup.entity;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.depth.learningcrew.common.auditor.TimeStampedEntity;
@@ -25,6 +26,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -64,7 +66,8 @@ public class StudyGroup extends TimeStampedEntity {
 
     @ManyToMany
     @JoinTable(name = "CATEGORY_GROUP_MAPPING", joinColumns = @JoinColumn(name = "study_group_id"), inverseJoinColumns = @JoinColumn(name = "group_category_id"))
-    private List<GroupCategory> categories;
+    @Builder.Default
+    private List<GroupCategory> categories = new ArrayList<>();
 
     @Column(nullable = false)
     private LocalDate startDate;

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationRepository.java
@@ -1,8 +1,17 @@
 package com.depth.learningcrew.domain.studygroup.repository;
 
-import com.depth.learningcrew.domain.studygroup.entity.Application;
-import com.depth.learningcrew.domain.studygroup.entity.ApplicationId;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.domain.studygroup.entity.ApplicationId;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.user.entity.User;
+
 public interface ApplicationRepository extends JpaRepository<Application, ApplicationId> {
+
+  Optional<Application> findById_UserAndId_StudyGroup(User user, StudyGroup studyGroup);
+
+  boolean existsById_UserAndId_StudyGroup(User user, StudyGroup studyGroup);
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/repository/MemberRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/repository/MemberRepository.java
@@ -1,8 +1,14 @@
 package com.depth.learningcrew.domain.studygroup.repository;
 
-import com.depth.learningcrew.domain.studygroup.entity.Member;
-import com.depth.learningcrew.domain.studygroup.entity.MemberId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.depth.learningcrew.domain.studygroup.entity.Member;
+import com.depth.learningcrew.domain.studygroup.entity.MemberId;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.user.entity.User;
+
 public interface MemberRepository extends JpaRepository<Member, MemberId> {
+
+  boolean existsById_UserAndId_StudyGroup(User user, StudyGroup studyGroup);
+
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationService.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationService.java
@@ -1,0 +1,57 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
+import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.domain.studygroup.entity.ApplicationId;
+import com.depth.learningcrew.domain.studygroup.entity.State;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.repository.ApplicationRepository;
+import com.depth.learningcrew.domain.studygroup.repository.MemberRepository;
+import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StudyGroupApplicationService {
+
+  private final StudyGroupRepository studyGroupRepository;
+  private final ApplicationRepository applicationRepository;
+  private final MemberRepository memberRepository;
+
+  @Transactional
+  public ApplicationDto.ApplicationResponse joinStudyGroup(Integer groupId, UserDetails userDetails) {
+    StudyGroup studyGroup = studyGroupRepository.findById(groupId)
+        .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+    cannotApplicateIfAlreadyMember(userDetails, studyGroup);
+    cannotApplicateIfAlreadySubmit(userDetails, studyGroup);
+
+    ApplicationId applicationId = ApplicationId.of(userDetails.getUser(), studyGroup);
+    Application application = Application.builder()
+        .id(applicationId)
+        .state(State.PENDING)
+        .build();
+
+    Application savedApplication = applicationRepository.save(application);
+    return ApplicationDto.ApplicationResponse.from(savedApplication);
+  }
+
+  private void cannotApplicateIfAlreadyMember(UserDetails userDetails, StudyGroup studyGroup) {
+    if (memberRepository.existsById_UserAndId_StudyGroup(userDetails.getUser(), studyGroup)) {
+      throw new RestException(ErrorCode.STUDY_GROUP_ALREADY_MEMBER);
+    }
+  }
+
+  private void cannotApplicateIfAlreadySubmit(UserDetails userDetails, StudyGroup studyGroup) {
+    if (applicationRepository.existsById_UserAndId_StudyGroup(userDetails.getUser(), studyGroup)) {
+      throw new RestException(ErrorCode.STUDY_GROUP_ALREADY_APPLIED);
+    }
+  }
+}

--- a/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
+++ b/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
@@ -51,8 +51,12 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(404, "댓글을 찾을 수 없습니다"),
     COMMENT_NOT_USER_TYPE(403, "사용자 댓글만 수정/삭제할 수 있습니다."),
 
+    // Study Group
+    STUDY_GROUP_ALREADY_MEMBER(400, "이미 스터디 그룹의 멤버입니다."),
+    STUDY_GROUP_ALREADY_APPLIED(400, "이미 가입 신청한 스터디 그룹입니다."),
+
     // Other
-    INTERNAL_SERVER_ERROR(500, "오류가 발생했습니다."), ;
+    INTERNAL_SERVER_ERROR(500, "오류가 발생했습니다."),;
 
     private final int statusCode;
     private final String message;

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationServiceIntegrationTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationServiceIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
+import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.domain.studygroup.entity.ApplicationId;
+import com.depth.learningcrew.domain.studygroup.entity.GroupCategory;
+import com.depth.learningcrew.domain.studygroup.entity.Member;
+import com.depth.learningcrew.domain.studygroup.entity.MemberId;
+import com.depth.learningcrew.domain.studygroup.entity.State;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.repository.ApplicationRepository;
+import com.depth.learningcrew.domain.studygroup.repository.GroupCategoryRepository;
+import com.depth.learningcrew.domain.studygroup.repository.MemberRepository;
+import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.domain.user.repository.UserRepository;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class StudyGroupApplicationServiceIntegrationTest {
+
+  @Autowired
+  private StudyGroupApplicationService studyGroupApplicationService;
+
+  @Autowired
+  private StudyGroupRepository studyGroupRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private ApplicationRepository applicationRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private GroupCategoryRepository groupCategoryRepository;
+
+  private User testUser;
+  private User ownerUser;
+  private StudyGroup testStudyGroup;
+  private GroupCategory testCategory;
+  private UserDetails userDetails;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 사용자 생성
+    testUser = User.builder()
+        .email("test@example.com")
+        .password("password")
+        .nickname("testUser")
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+    testUser = userRepository.save(testUser);
+
+    // 스터디 그룹 주최자 생성
+    ownerUser = User.builder()
+        .email("owner@example.com")
+        .password("password")
+        .nickname("ownerUser")
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+    ownerUser = userRepository.save(ownerUser);
+
+    // 테스트 카테고리 생성
+    testCategory = GroupCategory.builder()
+        .name("테스트 카테고리")
+        .build();
+    testCategory = groupCategoryRepository.save(testCategory);
+
+    // 테스트 스터디 그룹 생성
+    testStudyGroup = StudyGroup.builder()
+        .name("테스트 스터디 그룹")
+        .summary("테스트 스터디 그룹입니다.")
+        .content("테스트 스터디 그룹 내용입니다.")
+        .maxMembers(10)
+        .memberCount(1)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(3))
+        .owner(ownerUser)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+    testStudyGroup = studyGroupRepository.save(testStudyGroup);
+
+    // UserDetails 설정
+    userDetails = UserDetails.builder()
+        .user(testUser)
+        .build();
+  }
+
+  @Test
+  @DisplayName("정상적으로 가입 신청이 되는 경우")
+  void joinStudyGroup_success() {
+    // when
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.joinStudyGroup(
+        testStudyGroup.getId(), userDetails);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getState()).isEqualTo(State.PENDING);
+    assertThat(response.getUser().getEmail()).isEqualTo(testUser.getEmail());
+    assertThat(response.getStudyGroup().getId()).isEqualTo(testStudyGroup.getId());
+
+    // 데이터베이스에 실제로 저장되었는지 확인
+    ApplicationId applicationId = ApplicationId.of(testUser, testStudyGroup);
+    Application savedApplication = applicationRepository.findById(applicationId).orElse(null);
+    assertThat(savedApplication).isNotNull();
+    assertThat(savedApplication.getState()).isEqualTo(State.PENDING);
+  }
+
+  @Test
+  @DisplayName("이미 멤버인 경우 예외 발생")
+  void joinStudyGroup_alreadyMember() {
+    // given - 멤버로 등록
+    MemberId memberId = MemberId.builder()
+        .user(testUser)
+        .studyGroup(testStudyGroup)
+        .build();
+    Member member = Member.builder()
+        .id(memberId)
+        .build();
+    memberRepository.save(member);
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(testStudyGroup.getId(), userDetails))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining(ErrorCode.STUDY_GROUP_ALREADY_MEMBER.getMessage());
+  }
+
+  @Test
+  @DisplayName("이미 신청한 경우 예외 발생")
+  void joinStudyGroup_alreadyApplied() {
+    // given - 이미 신청한 상태
+    ApplicationId applicationId = ApplicationId.of(testUser, testStudyGroup);
+    Application application = Application.builder()
+        .id(applicationId)
+        .state(State.PENDING)
+        .build();
+    applicationRepository.save(application);
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(testStudyGroup.getId(), userDetails))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining(ErrorCode.STUDY_GROUP_ALREADY_APPLIED.getMessage());
+  }
+
+  @Test
+  @DisplayName("스터디 그룹이 존재하지 않는 경우 예외 발생")
+  void joinStudyGroup_groupNotFound() {
+    // when & then
+    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(99999, userDetails))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining(ErrorCode.GLOBAL_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("중복 신청 방지 확인")
+  void joinStudyGroup_duplicateApplicationPrevention() {
+    // given - 첫 번째 신청
+    ApplicationDto.ApplicationResponse firstResponse = studyGroupApplicationService.joinStudyGroup(
+        testStudyGroup.getId(), userDetails);
+    assertThat(firstResponse.getState()).isEqualTo(State.PENDING);
+
+    // when & then - 두 번째 신청 시도 시 예외 발생
+    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(testStudyGroup.getId(), userDetails))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining(ErrorCode.STUDY_GROUP_ALREADY_APPLIED.getMessage());
+  }
+}

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationServiceTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationServiceTest.java
@@ -1,0 +1,109 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
+import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.domain.studygroup.entity.State;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.repository.ApplicationRepository;
+import com.depth.learningcrew.domain.studygroup.repository.MemberRepository;
+import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+class StudyGroupApplicationServiceTest {
+
+  @Mock
+  private StudyGroupRepository studyGroupRepository;
+  @Mock
+  private ApplicationRepository applicationRepository;
+  @Mock
+  private MemberRepository memberRepository;
+  @Mock
+  private UserDetails userDetails;
+  @Mock
+  private User user;
+
+  @InjectMocks
+  private StudyGroupApplicationService studyGroupApplicationService;
+
+  private StudyGroup studyGroup;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    studyGroup = StudyGroup.builder().id(1).categories(new java.util.ArrayList<>()).owner(user).build();
+    when(userDetails.getUser()).thenReturn(user);
+  }
+
+  @Test
+  @DisplayName("정상적으로 가입 신청이 되는 경우")
+  void joinStudyGroup_success() {
+    // given
+    when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
+    when(memberRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(false);
+    when(applicationRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(false);
+    when(applicationRepository.save(any(Application.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.joinStudyGroup(1, userDetails);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.getState()).isEqualTo(State.PENDING);
+  }
+
+  @Test
+  @DisplayName("이미 멤버인 경우 예외 발생")
+  void joinStudyGroup_alreadyMember() {
+    // given
+    when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
+    when(memberRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(1, userDetails))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining(ErrorCode.STUDY_GROUP_ALREADY_MEMBER.getMessage());
+  }
+
+  @Test
+  @DisplayName("이미 신청한 경우 예외 발생")
+  void joinStudyGroup_alreadyApplied() {
+    // given
+    when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
+    when(memberRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(false);
+    when(applicationRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(1, userDetails))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining(ErrorCode.STUDY_GROUP_ALREADY_APPLIED.getMessage());
+  }
+
+  @Test
+  @DisplayName("스터디 그룹이 존재하지 않는 경우 예외 발생")
+  void joinStudyGroup_groupNotFound() {
+    // given
+    when(studyGroupRepository.findById(1)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(1, userDetails))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining(ErrorCode.GLOBAL_NOT_FOUND.getMessage());
+  }
+}


### PR DESCRIPTION
- StudyGroupApplicationController 클래스 추가 및 스터디 그룹 가입 신청 API 구현
- ApplicationDto 클래스 추가 및 스터디 그룹 가입 신청 응답 DTO 정의
- StudyGroupApplicationService 클래스 추가 및 가입 신청 로직 구현
- ApplicationRepository에 사용자와 스터디 그룹으로 신청 여부 확인 메서드 추가
- MemberRepository에 사용자와 스터디 그룹으로 멤버 여부 확인 메서드 추가
- GroupCategory 및 StudyGroup 엔티티에 Builder.Default 추가
- 관련 테스트 코드 추가: StudyGroupApplicationServiceIntegrationTest 및 StudyGroupApplicationServiceTest 클래스 생성
- ErrorCode에 스터디 그룹 관련 예외 코드 추가

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
