### PR TITLE
LNIT-42-JWT-인증-제외-API-어노테이션-기반으로-수정

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/depth/learningcrew/domain/auth/controller/AuthController.java
@@ -1,11 +1,22 @@
 package com.depth.learningcrew.domain.auth.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.depth.learningcrew.domain.auth.dto.AuthDto;
 import com.depth.learningcrew.domain.auth.service.AuthService;
 import com.depth.learningcrew.domain.user.dto.UserDto;
+import com.depth.learningcrew.system.security.annotation.NoJwtAuth;
 import com.depth.learningcrew.system.security.model.JwtDto;
 import com.depth.learningcrew.system.security.model.UserDetails;
 import com.depth.learningcrew.system.security.utility.validator.ValidatorUtil;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,9 +26,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final AuthService authService;
 
+    @NoJwtAuth("회원가입은 인증이 필요하지 않음")
     @PostMapping("/register")
     @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
     @ApiResponse(responseCode = "200", description = "회원가입 성공")
@@ -33,6 +42,7 @@ public class AuthController {
         return authService.signUp(request);
     }
 
+    @NoJwtAuth("로그인은 인증이 필요하지 않음")
     @PostMapping("/login")
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
@@ -40,6 +50,7 @@ public class AuthController {
         return authService.signIn(request);
     }
 
+    @NoJwtAuth("이메일 중복 확인은 회원가입 전 단계로 인증이 필요하지 않음")
     @GetMapping("/email-exist")
     @Operation(summary = "아이디 중복 확인", description = "입력된 아이디의 사용 가능 여부를 확인합니다.")
     @ApiResponse(responseCode = "200", description = "아이디 확인 성공")
@@ -48,6 +59,7 @@ public class AuthController {
         return authService.checkEmailExist(email);
     }
 
+    @NoJwtAuth("닉네임 중복 확인은 회원가입 전 단계로 인증이 필요하지 않음")
     @GetMapping("/nickname-exist")
     @Operation(summary = "닉네임 중복 확인", description = "입력된 닉네임의 사용 가능 여부를 확인합니다.")
     @ApiResponse(responseCode = "200", description = "닉네임 확인 성공")
@@ -56,6 +68,7 @@ public class AuthController {
         return authService.checkNicknameExist(nickname);
     }
 
+    @NoJwtAuth("토큰 갱신은 만료된 토큰으로 새 토큰을 발급받는 과정이므로 JWT 인증이 필요하지 않음")
     @PostMapping("/token/refresh")
     @Operation(summary = "토큰 재발행", description = "새로운 Access/Refresh Token을 재발급받습니다.")
     @ApiResponse(responseCode = "200", description = "토큰 재발행 성공")
@@ -65,19 +78,10 @@ public class AuthController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "현재 사용자의 Refresh Token을 삭제하며 로그아웃 처리합니다.")
-    @ApiResponse(
-            responseCode = "200",
-            description = "로그아웃 성공",
-            content = @Content(
-                    mediaType = "text/plain",
-                    examples = @ExampleObject(value = "Logout Successful")
-            )
-    )
+    @ApiResponse(responseCode = "200", description = "로그아웃 성공", content = @Content(mediaType = "text/plain", examples = @ExampleObject(value = "Logout Successful")))
     public ResponseEntity<String> logout(
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal UserDetails userDetails,
-            HttpServletRequest request
-    ) {
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+            HttpServletRequest request) {
         authService.logout(userDetails, request);
         return ResponseEntity.ok("Logout Successful");
     }

--- a/src/main/java/com/depth/learningcrew/domain/file/controller/FileController.java
+++ b/src/main/java/com/depth/learningcrew/domain/file/controller/FileController.java
@@ -1,10 +1,7 @@
 package com.depth.learningcrew.domain.file.controller;
 
-import com.depth.learningcrew.domain.file.service.FileService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +10,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
+import com.depth.learningcrew.domain.file.service.FileService;
+import com.depth.learningcrew.system.security.annotation.NoJwtAuth;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,32 +24,32 @@ import java.io.IOException;
 @Tag(name = "File", description = "파일 다운로드/조회 API")
 public class FileController {
 
-    private final FileService fileService;
+        private final FileService fileService;
 
-    @GetMapping("/images/{file_uuId}")
-    @Operation(summary = "이미지 조회", description = "특정 아이디로 저장된 이미지를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "이미지 조회 성공")
-    public ResponseEntity<Resource> getImage(
-            @PathVariable String file_uuId
-    ) {
-        Resource resource = fileService.getResourceById(file_uuId);
+        @NoJwtAuth("이미지 조회는 공개 리소스로 인증이 필요하지 않음")
+        @GetMapping("/images/{file_uuId}")
+        @Operation(summary = "이미지 조회", description = "특정 아이디로 저장된 이미지를 조회합니다.")
+        @ApiResponse(responseCode = "200", description = "이미지 조회 성공")
+        public ResponseEntity<Resource> getImage(
+                        @PathVariable String file_uuId) {
+                Resource resource = fileService.getResourceById(file_uuId);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .header("Content-Type", "image/jpeg")
-                .body(resource);
-    }
+                return ResponseEntity.status(HttpStatus.OK)
+                                .header("Content-Type", "image/jpeg")
+                                .body(resource);
+        }
 
-    @GetMapping("/downloads/{file_uuId}")
-    @Operation(summary = "파일 다운로드", description = "특정 아이디로 저장된 파일을 다운로드합니다.")
-    @ApiResponse(responseCode = "200", description = "파일 다운로드 성공")
-    public ResponseEntity<Resource> downloadFile(
-            @PathVariable String file_uuId
-    ) throws IOException {
-        Resource resource = fileService.getResourceById(file_uuId);
+        @NoJwtAuth("파일 다운로드는 공개 리소스로 인증이 필요하지 않음")
+        @GetMapping("/downloads/{file_uuId}")
+        @Operation(summary = "파일 다운로드", description = "특정 아이디로 저장된 파일을 다운로드합니다.")
+        @ApiResponse(responseCode = "200", description = "파일 다운로드 성공")
+        public ResponseEntity<Resource> downloadFile(
+                        @PathVariable String file_uuId) throws IOException {
+                Resource resource = fileService.getResourceById(file_uuId);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .header("Content-Disposition", "attachment; filename=\"" + file_uuId + "\"")
-                .header("Content-Type", "application/octet-stream")
-                .body(resource);
-    }
+                return ResponseEntity.status(HttpStatus.OK)
+                                .header("Content-Disposition", "attachment; filename=\"" + file_uuId + "\"")
+                                .header("Content-Type", "application/octet-stream")
+                                .body(resource);
+        }
 }

--- a/src/main/java/com/depth/learningcrew/system/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/depth/learningcrew/system/configuration/security/SecurityConfig.java
@@ -1,8 +1,7 @@
 package com.depth.learningcrew.system.configuration.security;
 
-import com.depth.learningcrew.system.security.configurer.JwtAutoConfigurerFactory;
-import com.depth.learningcrew.system.security.service.UserLoadServiceImpl;
-import lombok.RequiredArgsConstructor;
+import java.util.Arrays;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,7 +13,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
+import com.depth.learningcrew.system.security.configurer.JwtAutoConfigurerFactory;
+import com.depth.learningcrew.system.security.initializer.JwtAuthPathInitializer;
+import com.depth.learningcrew.system.security.service.UserLoadServiceImpl;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -22,22 +25,19 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final JwtAutoConfigurerFactory jwtAutoConfigurerFactory;
+    private final JwtAuthPathInitializer jwtAuthPathInitializer;
 
     @Bean
     SecurityFilterChain securityFilterChain(
             HttpSecurity httpSecurity,
-            UserLoadServiceImpl userLoadServiceImpl
-    ) throws Exception {
+            UserLoadServiceImpl userLoadServiceImpl) throws Exception {
         jwtAutoConfigurerFactory.create(userLoadServiceImpl)
                 .pathConfigure((it) -> {
+                    // 기본 포함 경로 설정
                     it.includePath("/api/**");
-                    it.excludePath("/api/auth/register");
-                    it.excludePath("/api/auth/login");
-                    it.excludePath("/api/auth/email-exist");
-                    it.excludePath("/api/auth/nickname-exist");
-                    it.excludePath("/api/auth/token/refresh");
-                    it.excludePath("/api/files/images/**");
-                    it.excludePath("/api/files/downloads/**");
+
+                    // @NoJwtAuth 어노테이션으로 자동 수집된 경로들 추가
+                    it.excludePaths(jwtAuthPathInitializer.getExcludePaths());
                 })
                 .configure(httpSecurity);
 

--- a/src/main/java/com/depth/learningcrew/system/security/annotation/NoJwtAuth.java
+++ b/src/main/java/com/depth/learningcrew/system/security/annotation/NoJwtAuth.java
@@ -1,0 +1,27 @@
+package com.depth.learningcrew.system.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * JWT 인증을 제외할 API 메서드나 컨트롤러 클래스에 사용하는 어노테이션
+ * 
+ * 사용법:
+ * 1. 메서드 레벨: 특정 메서드만 JWT 인증 제외
+ * 2. 클래스 레벨: 해당 컨트롤러의 모든 메서드 JWT 인증 제외
+ * 
+ * @author Learning Crew
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoJwtAuth {
+
+  /**
+   * 설명 (선택사항)
+   * 
+   * @return 인증 제외 이유나 설명
+   */
+  String value() default "";
+}

--- a/src/main/java/com/depth/learningcrew/system/security/configurer/PathPatternConfigurer.java
+++ b/src/main/java/com/depth/learningcrew/system/security/configurer/PathPatternConfigurer.java
@@ -1,24 +1,74 @@
 package com.depth.learningcrew.system.security.configurer;
 
-import lombok.Getter;
-
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+
+import lombok.Getter;
 
 @Getter
 public class PathPatternConfigurer {
     private final List<String> includePatternList = new ArrayList<>();
     private final List<String> excludePatternList = new ArrayList<>();
 
+    /**
+     * 포함할 경로 패턴 추가
+     * 
+     * @param path 포함할 경로
+     */
     public void includePath(String path) {
         this.includePatternList.add(path);
     }
 
+    /**
+     * 모든 경로 포함
+     */
     public void includeAll() {
         this.includePatternList.add("/**");
     }
 
+    /**
+     * 제외할 경로 패턴 추가
+     * 
+     * @param path 제외할 경로
+     */
     public void excludePath(String path) {
         this.excludePatternList.add(path);
+    }
+
+    /**
+     * 여러 경로를 한번에 제외 패턴에 추가
+     * 
+     * @param paths 제외할 경로들
+     */
+    public void excludePaths(Collection<String> paths) {
+        this.excludePatternList.addAll(paths);
+    }
+
+    /**
+     * 여러 경로를 한번에 포함 패턴에 추가
+     * 
+     * @param paths 포함할 경로들
+     */
+    public void includePaths(Collection<String> paths) {
+        this.includePatternList.addAll(paths);
+    }
+
+    /**
+     * 현재 설정된 제외 패턴 개수 반환
+     * 
+     * @return 제외 패턴 개수
+     */
+    public int getExcludePatternCount() {
+        return excludePatternList.size();
+    }
+
+    /**
+     * 현재 설정된 포함 패턴 개수 반환
+     * 
+     * @return 포함 패턴 개수
+     */
+    public int getIncludePatternCount() {
+        return includePatternList.size();
     }
 }

--- a/src/main/java/com/depth/learningcrew/system/security/initializer/JwtAuthPathInitializer.java
+++ b/src/main/java/com/depth/learningcrew/system/security/initializer/JwtAuthPathInitializer.java
@@ -1,0 +1,92 @@
+package com.depth.learningcrew.system.security.initializer;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import com.depth.learningcrew.system.security.annotation.NoJwtAuth;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JwtAuthPathInitializer implements ApplicationListener<ContextRefreshedEvent> {
+
+  private final RequestMappingHandlerMapping handlerMapping;
+
+  private final Set<String> excludePaths = new HashSet<>();
+  private volatile boolean initialized = false;
+
+  public JwtAuthPathInitializer(
+          @Qualifier("requestMappingHandlerMapping")
+          RequestMappingHandlerMapping handlerMapping
+  ) {
+    this.handlerMapping = handlerMapping;
+  }
+
+  @Override
+  public void onApplicationEvent(@NonNull ContextRefreshedEvent event) {
+    if (!initialized) {
+      synchronized (this) {
+        if (!initialized) {
+          scanAndCollectExcludePaths();
+          initialized = true;
+        }
+      }
+    }
+  }
+
+  private void scanAndCollectExcludePaths() {
+    Map<RequestMappingInfo, HandlerMethod> handlerMethods = handlerMapping.getHandlerMethods();
+
+    for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : handlerMethods.entrySet()) {
+      RequestMappingInfo mappingInfo = entry.getKey();
+      HandlerMethod handlerMethod = entry.getValue();
+
+      if (shouldExcludeFromJwtAuth(handlerMethod)) {
+        if (mappingInfo.getPathPatternsCondition() != null) { // Spring Boot 3.x
+          Set<String> patterns = mappingInfo.getPathPatternsCondition().getPatternValues();
+          if (patterns != null && !patterns.isEmpty()) {
+            excludePaths.addAll(patterns);
+            log.info("JWT 인증 제외 경로 추가: {} (메서드: {}.{})",
+                    patterns,
+                    handlerMethod.getBeanType().getSimpleName(),
+                    handlerMethod.getMethod().getName());
+          }
+        }
+      }
+    }
+    log.info("총 {}개의 경로가 JWT 인증에서 제외되었습니다: {}", excludePaths.size(), excludePaths);
+  }
+
+  private boolean shouldExcludeFromJwtAuth(HandlerMethod handlerMethod) {
+    Method method = handlerMethod.getMethod();
+    Class<?> beanType = handlerMethod.getBeanType();
+
+    NoJwtAuth methodAnnotation = AnnotationUtils.findAnnotation(method, NoJwtAuth.class);
+    if (methodAnnotation != null) return true;
+
+    NoJwtAuth classAnnotation = AnnotationUtils.findAnnotation(beanType, NoJwtAuth.class);
+    return classAnnotation != null;
+  }
+
+  public Set<String> getExcludePaths() {
+    return new HashSet<>(excludePaths);
+  }
+
+  public void addExcludePath(String path) {
+    excludePaths.add(path);
+    log.info("런타임에 JWT 인증 제외 경로 추가: {}", path);
+  }
+}


### PR DESCRIPTION
- AuthController와 FileController에 @NoJwtAuth 어노테이션을 추가하여 인증이 필요 없는 API 경로를 명시
- SecurityConfig에서 @NoJwtAuth 어노테이션으로 자동 수집된 경로를 제외하도록 설정
- JwtAuthPathInitializer 클래스를 추가하여 @NoJwtAuth 어노테이션이 적용된 경로를 스캔하고 수집하는 기능 구현
- PathPatternConfigurer 클래스에 여러 경로를 한번에 제외 및 포함할 수 있는 메서드 추가
- JwtAuthenticationFilter에서 코드 정리 및 예외 처리 개선

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
