### PR TITLE
LNIT-36-스터디-그룹-가입-신청-수락-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
@@ -33,4 +33,15 @@ public class StudyGroupApplicationController {
     ApplicationDto.ApplicationResponse response = studyGroupApplicationService.joinStudyGroup(groupId, userDetails);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
+
+  @PostMapping("/{groupId}/applications/{userId}/approve")
+  @Operation(summary = "스터디 그룹 가입 신청 수락", description = "스터디 그룹의 owner가 가입 신청을 수락합니다.")
+  public ResponseEntity<ApplicationDto.ApplicationResponse> approveApplication(
+      @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
+      @Parameter(description = "신청자 ID") @PathVariable Integer userId,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(groupId, userId,
+        userDetails);
+    return ResponseEntity.ok(response);
+  }
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/ApplicationDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/ApplicationDto.java
@@ -32,6 +32,9 @@ public class ApplicationDto {
     @Schema(description = "마지막 수정 시간", example = "2024-01-01T00:00:00")
     private LocalDateTime lastModifiedAt;
 
+    @Schema(description = "수락 시간", example = "2024-01-01T00:00:00")
+    private LocalDateTime approvedAt;
+
     @Schema(description = "신청 상태", example = "PENDING", allowableValues = { "PENDING", "APPROVED", "REJECTED" })
     private State state;
 
@@ -41,6 +44,7 @@ public class ApplicationDto {
           .studyGroup(StudyGroupDto.StudyGroupResponse.from(application.getId().getStudyGroup(), false))
           .createdAt(application.getCreatedAt())
           .lastModifiedAt(application.getLastModifiedAt())
+          .approvedAt(application.getApprovedAt())
           .state(application.getState())
           .build();
     }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/Application.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/Application.java
@@ -1,12 +1,26 @@
 package com.depth.learningcrew.domain.studygroup.entity;
 
+import java.time.LocalDateTime;
+
 import com.depth.learningcrew.common.auditor.TimeStampedEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+
+import com.depth.learningcrew.system.security.model.UserDetails;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
@@ -18,4 +32,33 @@ public class Application extends TimeStampedEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 40)
     private State state;
+
+    @Column
+    private LocalDateTime approvedAt;
+
+    public void approve() {
+        if (this.state == State.APPROVED) {
+            throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_APPROVED);
+        }
+        this.state = State.APPROVED;
+        this.approvedAt = LocalDateTime.now();
+    }
+
+    public void canApprovedBy(UserDetails userDetails) {
+        if (!this.id.getStudyGroup().getOwner().getId().equals(userDetails.getUser().getId())) {
+            throw new RestException(ErrorCode.AUTH_FORBIDDEN);
+        }
+    }
+
+    public void canApproveNow() {
+        //이미 승인된 신청은 승인할 수 없음
+        if (this.state == State.APPROVED) {
+            throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_APPROVED);
+        }
+
+        //신청이 거절된 경우 승인할 수 없음
+        if (this.state == State.REJECTED) {
+            throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_REJECTED);
+        }
+    }
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/Member.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/Member.java
@@ -1,9 +1,12 @@
 package com.depth.learningcrew.domain.studygroup.entity;
 
 import com.depth.learningcrew.common.auditor.TimeStampedEntity;
+
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationRepository.java
@@ -14,4 +14,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Applic
   Optional<Application> findById_UserAndId_StudyGroup(User user, StudyGroup studyGroup);
 
   boolean existsById_UserAndId_StudyGroup(User user, StudyGroup studyGroup);
+
+  Optional<Application> findById_User_IdAndId_StudyGroup_Id(Integer userId, Integer groupId);
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/repository/MemberRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.depth.learningcrew.domain.studygroup.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.depth.learningcrew.domain.studygroup.entity.Member;
@@ -11,4 +13,5 @@ public interface MemberRepository extends JpaRepository<Member, MemberId> {
 
   boolean existsById_UserAndId_StudyGroup(User user, StudyGroup studyGroup);
 
+  Optional<Member> findById_UserAndId_StudyGroup(User user, StudyGroup studyGroup);
 }

--- a/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/user/dto/UserDto.java
@@ -24,6 +24,8 @@ public class UserDto {
     @AllArgsConstructor
     @Getter
     public static class UserResponse {
+        @Schema(description = "사용자 ID", example = "1")
+        private Integer id;
         @Schema(description = "이메일(아이디)", example = "user@email.com")
         private String email;
         @Schema(description = "사용자 닉네임", example = "user nickname")
@@ -41,6 +43,7 @@ public class UserDto {
 
         public static UserResponse from(User user) {
             return UserResponse.builder()
+                    .id(user.getId())
                     .email(user.getEmail())
                     .nickname(user.getNickname())
                     .role(user.getRole())

--- a/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
+++ b/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
@@ -54,6 +54,8 @@ public enum ErrorCode {
     // Study Group
     STUDY_GROUP_ALREADY_MEMBER(400, "이미 스터디 그룹의 멤버입니다."),
     STUDY_GROUP_ALREADY_APPLIED(400, "이미 가입 신청한 스터디 그룹입니다."),
+    STUDY_GROUP_APPLICATION_ALREADY_APPROVED(400, "이미 수락된 신청입니다."),
+    STUDY_GROUP_APPLICATION_ALREADY_REJECTED(400, "이미 거절된 신청입니다."),
 
     // Other
     INTERNAL_SERVER_ERROR(500, "오류가 발생했습니다."),;

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationServiceTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationServiceTest.java
@@ -5,105 +5,183 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
 import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.domain.studygroup.entity.ApplicationId;
+import com.depth.learningcrew.domain.studygroup.entity.Member;
 import com.depth.learningcrew.domain.studygroup.entity.State;
 import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
 import com.depth.learningcrew.domain.studygroup.repository.ApplicationRepository;
 import com.depth.learningcrew.domain.studygroup.repository.MemberRepository;
 import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
 import com.depth.learningcrew.domain.user.entity.User;
 import com.depth.learningcrew.system.exception.model.ErrorCode;
 import com.depth.learningcrew.system.exception.model.RestException;
 import com.depth.learningcrew.system.security.model.UserDetails;
 
+@ExtendWith(MockitoExtension.class)
 class StudyGroupApplicationServiceTest {
 
   @Mock
   private StudyGroupRepository studyGroupRepository;
+
   @Mock
   private ApplicationRepository applicationRepository;
+
   @Mock
   private MemberRepository memberRepository;
-  @Mock
-  private UserDetails userDetails;
-  @Mock
-  private User user;
 
   @InjectMocks
   private StudyGroupApplicationService studyGroupApplicationService;
 
+  private User owner;
+  private User applicant;
   private StudyGroup studyGroup;
+  private Application application;
+  private UserDetails ownerDetails;
+  private UserDetails applicantDetails;
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.openMocks(this);
-    studyGroup = StudyGroup.builder().id(1).categories(new java.util.ArrayList<>()).owner(user).build();
-    when(userDetails.getUser()).thenReturn(user);
+    owner = User.builder()
+        .id(1)
+        .email("owner@test.com")
+        .password("password")
+        .nickname("owner")
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .build();
+
+    applicant = User.builder()
+        .id(2)
+        .email("applicant@test.com")
+        .password("password")
+        .nickname("applicant")
+        .birthday(LocalDate.of(1995, 5, 15))
+        .gender(Gender.FEMALE)
+        .role(Role.USER)
+        .build();
+
+    studyGroup = StudyGroup.builder()
+        .id(1)
+        .name("Test Study Group")
+        .summary("Test Summary")
+        .content("Test Content")
+        .maxMembers(10)
+        .memberCount(1)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(3))
+        .owner(owner)
+        .build();
+
+    ApplicationId applicationId = ApplicationId.of(applicant, studyGroup);
+    application = Application.builder()
+        .id(applicationId)
+        .state(State.PENDING)
+        .build();
+
+    ownerDetails = new UserDetails(owner);
+    applicantDetails = new UserDetails(applicant);
   }
 
   @Test
-  @DisplayName("정상적으로 가입 신청이 되는 경우")
-  void joinStudyGroup_success() {
+  @DisplayName("가입 신청 수락 성공")
+  void approveApplication_Success() {
     // given
     when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
-    when(memberRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(false);
-    when(applicationRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(false);
-    when(applicationRepository.save(any(Application.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(applicationRepository.findById_User_IdAndId_StudyGroup_Id(2, 1)).thenReturn(Optional.of(application));
+    when(memberRepository.existsById_UserAndId_StudyGroup(applicant, studyGroup)).thenReturn(false);
+    when(memberRepository.save(any(Member.class))).thenReturn(new Member());
+    when(studyGroupRepository.save(any(StudyGroup.class))).thenReturn(studyGroup);
 
     // when
-    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.joinStudyGroup(1, userDetails);
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(1, 2, ownerDetails);
 
     // then
-    assertThat(response).isNotNull();
-    assertThat(response.getState()).isEqualTo(State.PENDING);
+    assertThat(response.getState()).isEqualTo(State.APPROVED);
+    assertThat(response.getApprovedAt()).isNotNull();
   }
 
   @Test
-  @DisplayName("이미 멤버인 경우 예외 발생")
-  void joinStudyGroup_alreadyMember() {
+  @DisplayName("가입 신청 수락 실패 - 권한 없음")
+  void approveApplication_Fail_NoPermission() {
     // given
     when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
-    when(memberRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(true);
+    when(applicationRepository.findById_User_IdAndId_StudyGroup_Id(2, 1)).thenReturn(Optional.of(application));
 
     // when & then
-    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(1, userDetails))
+    assertThatThrownBy(() -> studyGroupApplicationService.approveApplication(1, 2, applicantDetails))
         .isInstanceOf(RestException.class)
-        .hasMessageContaining(ErrorCode.STUDY_GROUP_ALREADY_MEMBER.getMessage());
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
   }
 
   @Test
-  @DisplayName("이미 신청한 경우 예외 발생")
-  void joinStudyGroup_alreadyApplied() {
+  @DisplayName("가입 신청 수락 실패 - 이미 수락된 신청")
+  void approveApplication_Fail_AlreadyApproved() {
     // given
+    application.setState(State.APPROVED);
     when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
-    when(memberRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(false);
-    when(applicationRepository.existsById_UserAndId_StudyGroup(user, studyGroup)).thenReturn(true);
+    when(applicationRepository.findById_User_IdAndId_StudyGroup_Id(2, 1)).thenReturn(Optional.of(application));
 
     // when & then
-    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(1, userDetails))
+    assertThatThrownBy(() -> studyGroupApplicationService.approveApplication(1, 2, ownerDetails))
         .isInstanceOf(RestException.class)
-        .hasMessageContaining(ErrorCode.STUDY_GROUP_ALREADY_APPLIED.getMessage());
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_APPROVED);
   }
 
   @Test
-  @DisplayName("스터디 그룹이 존재하지 않는 경우 예외 발생")
-  void joinStudyGroup_groupNotFound() {
+  @DisplayName("가입 신청 수락 실패 - 스터디 그룹 없음")
+  void approveApplication_Fail_StudyGroupNotFound() {
     // given
     when(studyGroupRepository.findById(1)).thenReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> studyGroupApplicationService.joinStudyGroup(1, userDetails))
+    assertThatThrownBy(() -> studyGroupApplicationService.approveApplication(1, 2, ownerDetails))
         .isInstanceOf(RestException.class)
-        .hasMessageContaining(ErrorCode.GLOBAL_NOT_FOUND.getMessage());
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("가입 신청 수락 실패 - 신청서 없음")
+  void approveApplication_Fail_ApplicationNotFound() {
+    // given
+    when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
+    when(applicationRepository.findById_User_IdAndId_StudyGroup_Id(2, 1)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> studyGroupApplicationService.approveApplication(1, 2, ownerDetails))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("가입 신청 수락 성공 - 이미 멤버인 경우")
+  void approveApplication_Success_AlreadyMember() {
+    // given
+    when(studyGroupRepository.findById(1)).thenReturn(Optional.of(studyGroup));
+    when(applicationRepository.findById_User_IdAndId_StudyGroup_Id(2, 1)).thenReturn(Optional.of(application));
+    when(memberRepository.existsById_UserAndId_StudyGroup(applicant, studyGroup)).thenReturn(true);
+
+    // when
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(1, 2, ownerDetails);
+
+    // then
+    assertThat(response.getState()).isEqualTo(State.APPROVED);
+    assertThat(response.getApprovedAt()).isNotNull();
   }
 }


### PR DESCRIPTION
- StudyGroupApplicationController에 가입 신청 수락 API 추가
- ApplicationDto에 수락 시간 필드 추가
- Application 엔티티에 수락 관련 메서드 및 필드 추가
- StudyGroupApplicationService에 가입 신청 수락 로직 구현
- ApplicationRepository 및 MemberRepository에 필요한 메서드 추가
- 관련 테스트 코드 추가: StudyGroupApplicationServiceIntegrationTest 및 StudyGroupApplicationServiceTest 클래스 업데이트
- ErrorCode에 스터디 그룹 신청 수락 관련 예외 코드 추가

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
