### PR TITLE
LNIT-35-스터디의-가입-신청-현황-모두-조회-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
@@ -1,11 +1,17 @@
 package com.depth.learningcrew.domain.studygroup.controller;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
@@ -25,23 +31,37 @@ public class StudyGroupApplicationController {
 
   private final StudyGroupApplicationService studyGroupApplicationService;
 
+  @GetMapping("/{groupId}/applications")
+  @Operation(summary = "스터디 그룹 가입 신청 목록 조회", description = "스터디 그룹의 owner가 가입 신청 목록을 페이지네이션으로 조회합니다.")
+  public PagedModel<ApplicationDto.ApplicationResponse> getApplicationsByGroupId(
+      @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
+      @ModelAttribute @ParameterObject ApplicationDto.SearchConditions searchConditions,
+      @PageableDefault @ParameterObject Pageable pageable,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+
+    PagedModel<ApplicationDto.ApplicationResponse> response = studyGroupApplicationService.getApplicationsByGroupId(groupId, searchConditions, userDetails, pageable);
+    return response;
+  }
+
   @PostMapping("/{groupId}/join")
   @Operation(summary = "스터디 그룹 가입 신청", description = "로그인한 사용자가 특정 스터디 그룹에 가입 신청을 합니다.")
-  public ResponseEntity<ApplicationDto.ApplicationResponse> joinStudyGroup(
+  @ResponseStatus(HttpStatus.CREATED)
+  public ApplicationDto.ApplicationResponse joinStudyGroup(
       @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+
     ApplicationDto.ApplicationResponse response = studyGroupApplicationService.joinStudyGroup(groupId, userDetails);
-    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    return response;
   }
 
   @PostMapping("/{groupId}/applications/{userId}/approve")
   @Operation(summary = "스터디 그룹 가입 신청 수락", description = "스터디 그룹의 owner가 가입 신청을 수락합니다.")
-  public ResponseEntity<ApplicationDto.ApplicationResponse> approveApplication(
+  public ApplicationDto.ApplicationResponse approveApplication(
       @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
       @Parameter(description = "신청자 ID") @PathVariable Integer userId,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
-    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(groupId, userId,
-        userDetails);
-    return ResponseEntity.ok(response);
+
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(groupId, userId, userDetails);
+    return response;
   }
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/ApplicationDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/ApplicationDto.java
@@ -49,4 +49,25 @@ public class ApplicationDto {
           .build();
     }
   }
+
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Getter
+  @Schema(description = "스터디 그룹 가입 신청 검색 조건")
+  public static class SearchConditions {
+    @Schema(description = "신청자 이름 검색", example = "홍길동")
+    private String name;
+
+    @Schema(description = "신청 상태 필터", example = "PENDING", allowableValues = { "PENDING", "APPROVED", "REJECTED" })
+    private State state;
+
+    @Schema(description = "정렬 기준", example = "created_at", allowableValues = { "created_at", "alphabet" })
+    @Builder.Default
+    private String sort = "created_at";
+
+    @Schema(description = "정렬 순서", example = "desc", allowableValues = { "asc", "desc" })
+    @Builder.Default
+    private String order = "desc";
+  }
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationQueryRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationQueryRepository.java
@@ -1,0 +1,126 @@
+package com.depth.learningcrew.domain.studygroup.repository;
+
+import static com.depth.learningcrew.domain.studygroup.entity.QApplication.application;
+import static com.depth.learningcrew.domain.studygroup.entity.QStudyGroup.studyGroup;
+import static com.depth.learningcrew.domain.user.entity.QUser.user;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
+import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.system.security.model.UserDetails;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ApplicationQueryRepository {
+  private final JPAQueryFactory queryFactory;
+
+  /**
+   * 스터디 그룹의 가입 신청 목록을 페이지네이션하여 조회합니다.
+   *
+   * @param groupId          스터디 그룹 ID
+   * @param searchConditions 검색 조건
+   * @param userDetails      로그인 사용자 정보 (owner 권한 확인용)
+   * @param pageable         페이지 정보
+   * @return 페이지네이션된 가입 신청 목록
+   */
+  public Page<ApplicationDto.ApplicationResponse> paginateApplicationsByGroupId(
+      Integer groupId,
+      ApplicationDto.SearchConditions searchConditions,
+      UserDetails userDetails,
+      Pageable pageable) {
+
+    var query = queryFactory
+        .select(application)
+        .from(application)
+        .join(application.id.studyGroup, studyGroup)
+        .join(application.id.user, user)
+        .where(studyGroup.id.eq(groupId),
+            studyGroup.owner.id.eq(userDetails.getUser().getId()));
+
+    // 검색 조건 적용
+    var searchCondition = buildSearchCondition(searchConditions);
+    if (searchCondition != null) {
+      query = query.where(searchCondition);
+    }
+
+    // 정렬 조건 적용
+    applySorting(query, searchConditions);
+
+    List<Application> results = query
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    // 총 개수 조회
+    var countQuery = queryFactory
+        .select(application.count())
+        .from(application)
+        .join(application.id.studyGroup, studyGroup)
+        .where(studyGroup.id.eq(groupId),
+            studyGroup.owner.id.eq(userDetails.getUser().getId()));
+
+    if (searchCondition != null) {
+      countQuery = countQuery.where(searchCondition);
+    }
+
+    Long totalCount = countQuery.fetchOne();
+
+    List<ApplicationDto.ApplicationResponse> content = results.stream()
+        .map(ApplicationDto.ApplicationResponse::from)
+        .toList();
+
+    return new PageImpl<>(content, pageable, totalCount != null ? totalCount : 0L);
+  }
+
+  private BooleanExpression buildSearchCondition(ApplicationDto.SearchConditions searchConditions) {
+    BooleanExpression predicate = null;
+
+    // 상태 필터링
+    if (searchConditions.getState() != null) {
+      predicate = application.state.eq(searchConditions.getState());
+    }
+
+    // 이름 검색
+    if (StringUtils.hasText(searchConditions.getName())) {
+      BooleanExpression namePredicate = user.nickname.containsIgnoreCase(searchConditions.getName());
+      if (predicate != null) {
+        predicate = predicate.and(namePredicate);
+      } else {
+        predicate = namePredicate;
+      }
+    }
+
+    return predicate;
+  }
+
+  private void applySorting(JPAQuery<Application> query, ApplicationDto.SearchConditions searchConditions) {
+    String sort = searchConditions.getSort();
+    String order = searchConditions.getOrder();
+
+    if ("alphabet".equals(sort)) {
+      if ("asc".equals(order)) {
+        query.orderBy(user.nickname.asc());
+      } else {
+        query.orderBy(user.nickname.desc());
+      }
+    } else { // created_at (기본값)
+      if ("asc".equals(order)) {
+        query.orderBy(application.createdAt.asc());
+      } else {
+        query.orderBy(application.createdAt.desc());
+      }
+    }
+  }
+}

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationQueryRepositoryTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/repository/ApplicationQueryRepositoryTest.java
@@ -1,0 +1,253 @@
+package com.depth.learningcrew.domain.studygroup.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.studygroup.dto.ApplicationDto;
+import com.depth.learningcrew.domain.studygroup.entity.Application;
+import com.depth.learningcrew.domain.studygroup.entity.ApplicationId;
+import com.depth.learningcrew.domain.studygroup.entity.GroupCategory;
+import com.depth.learningcrew.domain.studygroup.entity.State;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.domain.user.repository.UserRepository;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ApplicationQueryRepositoryTest {
+
+    @Autowired
+    private ApplicationQueryRepository applicationQueryRepository;
+
+    @Autowired
+    private ApplicationRepository applicationRepository;
+
+    @Autowired
+    private StudyGroupRepository studyGroupRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GroupCategoryRepository groupCategoryRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private User owner;
+    private User applicant1;
+    private User applicant2;
+    private User applicant3;
+    private StudyGroup studyGroup;
+    private GroupCategory category;
+
+    @BeforeEach
+    void setUp() {
+        // 사용자 생성
+        owner = User.builder()
+                .nickname("스터디장")
+                .email("owner@test.com")
+                .password("password")
+                .role(Role.USER)
+                .gender(Gender.MALE)
+                .birthday(LocalDate.of(1990, 1, 1))
+                .build();
+        userRepository.save(owner);
+
+        applicant1 = User.builder()
+                .nickname("신청자1")
+                .email("applicant1@test.com")
+                .password("password")
+                .role(Role.USER)
+                .gender(Gender.FEMALE)
+                .birthday(LocalDate.of(1990, 1, 1))
+                .build();
+        userRepository.save(applicant1);
+
+        applicant2 = User.builder()
+                .nickname("신청자2")
+                .email("applicant2@test.com")
+                .password("password")
+                .role(Role.USER)
+                .gender(Gender.MALE)
+                .birthday(LocalDate.of(1990, 1, 1))
+                .build();
+        userRepository.save(applicant2);
+
+        applicant3 = User.builder()
+                .nickname("김신청")
+                .email("applicant3@test.com")
+                .password("password")
+                .role(Role.USER)
+                .gender(Gender.FEMALE)
+                .birthday(LocalDate.of(1990, 1, 1))
+                .build();
+        userRepository.save(applicant3);
+
+        // 카테고리 생성
+        category = GroupCategory.builder()
+                .name("프로그래밍")
+                .build();
+        groupCategoryRepository.save(category);
+
+        // 스터디 그룹 생성
+        studyGroup = StudyGroup.builder()
+                .name("테스트 스터디")
+                .summary("테스트용 스터디입니다.")
+                .content("테스트용 스터디 상세 내용입니다.")
+                .owner(owner)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusWeeks(2))
+                .memberCount(1)
+                .maxMembers(10)
+                .currentStep(1)
+                .categories(List.of(category))
+                .build();
+        studyGroupRepository.save(studyGroup);
+
+        // 가입 신청 생성
+        Application application1 = Application.builder()
+                .id(ApplicationId.of(applicant1, studyGroup))
+                .state(State.PENDING)
+                .build();
+        applicationRepository.save(application1);
+
+        Application application2 = Application.builder()
+                .id(ApplicationId.of(applicant2, studyGroup))
+                .state(State.APPROVED)
+                .build();
+        applicationRepository.save(application2);
+
+        Application application3 = Application.builder()
+                .id(ApplicationId.of(applicant3, studyGroup))
+                .state(State.PENDING)
+                .build();
+        applicationRepository.save(application3);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("스터디 그룹의 모든 가입 신청을 페이지네이션으로 조회할 수 있다")
+    void paginateApplicationsByGroupId() {
+        // given
+        UserDetails userDetails = new UserDetails(owner);
+        ApplicationDto.SearchConditions searchConditions = ApplicationDto.SearchConditions.builder().build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<ApplicationDto.ApplicationResponse> result = applicationQueryRepository
+                .paginateApplicationsByGroupId(studyGroup.getId(), searchConditions, userDetails, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("상태별로 가입 신청을 필터링할 수 있다")
+    void filterByState() {
+        // given
+        UserDetails userDetails = new UserDetails(owner);
+        ApplicationDto.SearchConditions searchConditions = ApplicationDto.SearchConditions.builder()
+                .state(State.PENDING)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<ApplicationDto.ApplicationResponse> result = applicationQueryRepository
+                .paginateApplicationsByGroupId(studyGroup.getId(), searchConditions, userDetails, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).allMatch(app -> app.getState() == State.PENDING);
+    }
+
+    @Test
+    @DisplayName("신청자 이름으로 검색할 수 있다")
+    void searchByName() {
+        // given
+        UserDetails userDetails = new UserDetails(owner);
+        ApplicationDto.SearchConditions searchConditions = ApplicationDto.SearchConditions.builder()
+                .name("김신청")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<ApplicationDto.ApplicationResponse> result = applicationQueryRepository
+                .paginateApplicationsByGroupId(studyGroup.getId(), searchConditions, userDetails, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("김신청");
+    }
+
+    @Test
+    @DisplayName("생성일 기준으로 정렬할 수 있다")
+    void sortByCreatedAt() {
+        // given
+        UserDetails userDetails = new UserDetails(owner);
+        ApplicationDto.SearchConditions searchConditions = ApplicationDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("asc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<ApplicationDto.ApplicationResponse> result = applicationQueryRepository
+                .paginateApplicationsByGroupId(studyGroup.getId(), searchConditions, userDetails, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        // 생성일 순서대로 정렬되었는지 확인
+        List<ApplicationDto.ApplicationResponse> content = result.getContent();
+        assertThat(content.get(0).getCreatedAt()).isBeforeOrEqualTo(content.get(1).getCreatedAt());
+        assertThat(content.get(1).getCreatedAt()).isBeforeOrEqualTo(content.get(2).getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("알파벳 순으로 정렬할 수 있다")
+    void sortByAlphabet() {
+        // given
+        UserDetails userDetails = new UserDetails(owner);
+        ApplicationDto.SearchConditions searchConditions = ApplicationDto.SearchConditions.builder()
+                .sort("alphabet")
+                .order("asc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<ApplicationDto.ApplicationResponse> result = applicationQueryRepository
+                .paginateApplicationsByGroupId(studyGroup.getId(), searchConditions, userDetails, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        // 알파벳 순서대로 정렬되었는지 확인
+        List<ApplicationDto.ApplicationResponse> content = result.getContent();
+        assertThat(content.get(0).getUser().getNickname()).isEqualTo("김신청");
+        assertThat(content.get(1).getUser().getNickname()).isEqualTo("신청자1");
+        assertThat(content.get(2).getUser().getNickname()).isEqualTo("신청자2");
+    }
+} 


### PR DESCRIPTION
- StudyGroupApplicationController에 가입 신청 목록 조회 API 추가
- ApplicationDto에 검색 조건을 위한 SearchConditions 클래스 추가
- ApplicationQueryRepository를 통해 가입 신청 목록을 페이지네이션하여 조회하는 로직 구현
- StudyGroupApplicationService에 가입 신청 목록 조회 메서드 추가
- 관련 테스트 코드 추가: ApplicationQueryRepositoryTest 클래스 생성 및 테스트 케이스 작성

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
