### PR TITLE
LNIT-39-스터디-그룹-가입-신청-거절-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
@@ -6,6 +6,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,7 +40,8 @@ public class StudyGroupApplicationController {
       @PageableDefault @ParameterObject Pageable pageable,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
 
-    PagedModel<ApplicationDto.ApplicationResponse> response = studyGroupApplicationService.getApplicationsByGroupId(groupId, searchConditions, userDetails, pageable);
+    PagedModel<ApplicationDto.ApplicationResponse> response = studyGroupApplicationService
+        .getApplicationsByGroupId(groupId, searchConditions, userDetails, pageable);
     return response;
   }
 
@@ -61,7 +63,20 @@ public class StudyGroupApplicationController {
       @Parameter(description = "신청자 ID") @PathVariable Integer userId,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
 
-    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(groupId, userId, userDetails);
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(groupId, userId,
+        userDetails);
+    return response;
+  }
+
+  @DeleteMapping("/{groupId}/applications/{userId}")
+  @Operation(summary = "스터디 그룹 가입 신청 거절", description = "스터디 그룹의 owner가 가입 신청을 거절합니다.")
+  public ApplicationDto.ApplicationResponse rejectApplication(
+      @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
+      @Parameter(description = "신청자 ID") @PathVariable Integer userId,
+      @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
+
+    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.rejectApplication(groupId, userId,
+        userDetails);
     return response;
   }
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupApplicationController.java
@@ -40,9 +40,8 @@ public class StudyGroupApplicationController {
       @PageableDefault @ParameterObject Pageable pageable,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
 
-    PagedModel<ApplicationDto.ApplicationResponse> response = studyGroupApplicationService
-        .getApplicationsByGroupId(groupId, searchConditions, userDetails, pageable);
-    return response;
+      return studyGroupApplicationService
+              .getApplicationsByGroupId(groupId, searchConditions, userDetails, pageable);
   }
 
   @PostMapping("/{groupId}/join")
@@ -52,8 +51,7 @@ public class StudyGroupApplicationController {
       @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
 
-    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.joinStudyGroup(groupId, userDetails);
-    return response;
+      return studyGroupApplicationService.joinStudyGroup(groupId, userDetails);
   }
 
   @PostMapping("/{groupId}/applications/{userId}/approve")
@@ -63,20 +61,16 @@ public class StudyGroupApplicationController {
       @Parameter(description = "신청자 ID") @PathVariable Integer userId,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
 
-    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.approveApplication(groupId, userId,
-        userDetails);
-    return response;
+      return studyGroupApplicationService.approveApplication(groupId, userId, userDetails);
   }
 
-  @DeleteMapping("/{groupId}/applications/{userId}")
+  @PostMapping("/{groupId}/applications/{userId}/reject")
   @Operation(summary = "스터디 그룹 가입 신청 거절", description = "스터디 그룹의 owner가 가입 신청을 거절합니다.")
   public ApplicationDto.ApplicationResponse rejectApplication(
       @Parameter(description = "스터디 그룹 ID") @PathVariable Integer groupId,
       @Parameter(description = "신청자 ID") @PathVariable Integer userId,
       @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
 
-    ApplicationDto.ApplicationResponse response = studyGroupApplicationService.rejectApplication(groupId, userId,
-        userDetails);
-    return response;
+      return studyGroupApplicationService.rejectApplication(groupId, userId, userDetails);
   }
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/Application.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/Application.java
@@ -5,8 +5,8 @@ import java.time.LocalDateTime;
 import com.depth.learningcrew.common.auditor.TimeStampedEntity;
 import com.depth.learningcrew.system.exception.model.ErrorCode;
 import com.depth.learningcrew.system.exception.model.RestException;
-
 import com.depth.learningcrew.system.security.model.UserDetails;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
@@ -44,19 +44,45 @@ public class Application extends TimeStampedEntity {
         this.approvedAt = LocalDateTime.now();
     }
 
+    public void reject() {
+        if (this.state == State.REJECTED) {
+            throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_REJECTED);
+        }
+        this.state = State.REJECTED;
+        this.approvedAt = LocalDateTime.now();
+    }
+
     public void canApprovedBy(UserDetails userDetails) {
         if (!this.id.getStudyGroup().getOwner().getId().equals(userDetails.getUser().getId())) {
             throw new RestException(ErrorCode.AUTH_FORBIDDEN);
         }
     }
 
+    public void canRejectBy(UserDetails userDetails) {
+        if (!this.id.getStudyGroup().getOwner().getId().equals(userDetails.getUser().getId())) {
+            throw new RestException(ErrorCode.AUTH_FORBIDDEN);
+        }
+    }
+
     public void canApproveNow() {
-        //이미 승인된 신청은 승인할 수 없음
+        // 이미 승인된 신청은 승인할 수 없음
         if (this.state == State.APPROVED) {
             throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_APPROVED);
         }
 
-        //신청이 거절된 경우 승인할 수 없음
+        // 신청이 거절된 경우 승인할 수 없음
+        if (this.state == State.REJECTED) {
+            throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_REJECTED);
+        }
+    }
+
+    public void canRejectNow() {
+        // 이미 승인된 신청은 거절할 수 없음
+        if (this.state == State.APPROVED) {
+            throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_APPROVED);
+        }
+
+        // 이미 거절된 신청은 거절할 수 없음
         if (this.state == State.REJECTED) {
             throw new RestException(ErrorCode.STUDY_GROUP_APPLICATION_ALREADY_REJECTED);
         }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationService.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupApplicationService.java
@@ -102,6 +102,23 @@ public class StudyGroupApplicationService {
     return ApplicationDto.ApplicationResponse.from(application);
   }
 
+  @Transactional
+  public ApplicationDto.ApplicationResponse rejectApplication(Integer groupId, Integer userId,
+      UserDetails ownerDetails) {
+    if (!studyGroupRepository.existsById(groupId)) {
+      throw new RestException(ErrorCode.GLOBAL_NOT_FOUND);
+    }
+
+    Application application = applicationRepository.findById_User_IdAndId_StudyGroup_Id(userId, groupId)
+        .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+    application.canRejectBy(ownerDetails);
+    application.canRejectNow();
+    application.reject();
+
+    return ApplicationDto.ApplicationResponse.from(application);
+  }
+
   private void cannotApplicateIfAlreadyMember(UserDetails userDetails, StudyGroup studyGroup) {
     if (memberRepository.existsById_UserAndId_StudyGroup(userDetails.getUser(), studyGroup)) {
       throw new RestException(ErrorCode.STUDY_GROUP_ALREADY_MEMBER);


### PR DESCRIPTION
- StudyGroupApplicationController에 가입 신청 거절 API 추가
- Application 엔티티에 거절 관련 메서드 추가
- StudyGroupApplicationService에 가입 신청 거절 로직 구현
- 관련 테스트 코드 추가: StudyGroupApplicationServiceIntegrationTest 및 StudyGroupApplicationServiceTest 클래스 업데이트
- ErrorCode에 스터디 그룹 신청 거절 관련 예외 코드 추가

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
