### PR TITLE
LNIT-40-스터디-그룹의-멤버-페이지네이션-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/MemberController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/MemberController.java
@@ -1,0 +1,41 @@
+package com.depth.learningcrew.domain.studygroup.controller;
+
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
+import com.depth.learningcrew.domain.studygroup.service.MemberService;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/study-groups/{groupId}/members")
+@Tag(name = "Study Group Member", description = "스터디 그룹 멤버 API")
+@RequiredArgsConstructor
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @GetMapping
+  @Operation(summary = "스터디 그룹 멤버 조회", description = "그룹의 owner 권한을 가진 사용자가 스터디 그룹의 멤버를 페이징하여 조회합니다.")
+  public PagedModel<MemberDto.MemberResponse> getStudyGroupMembers(@PathVariable Long groupId,
+      @ModelAttribute @ParameterObject MemberDto.SearchConditions searchConditions,
+      @PageableDefault(page = 0, size = 10) @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal UserDetails userDetails) {
+
+    return memberService.paginateStudyGroupMembers(groupId, searchConditions, userDetails, pageable);
+  }
+
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/MemberDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/MemberDto.java
@@ -1,0 +1,52 @@
+package com.depth.learningcrew.domain.studygroup.dto;
+
+import java.time.LocalDateTime;
+
+import com.depth.learningcrew.domain.studygroup.entity.Member;
+import com.depth.learningcrew.domain.user.dto.UserDto.UserResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class MemberDto {
+
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Data
+  @Schema(description = "멤버 검색 조건")
+  public static class SearchConditions {
+    @Schema(description = "정렬 기준", example = "created_at", allowableValues = { "created_at", "alphabet" })
+    private String sort;
+
+    @Schema(description = "정렬 순서", example = "desc", allowableValues = { "asc", "desc" })
+    private String order;
+  }
+
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Data
+  @Schema(description = "멤버 정보 응답")
+  public static class MemberResponse {
+    @Schema(description = "사용자 정보")
+    private UserResponse user;
+
+    @Schema(description = "생성일시", example = "2024-01-01T00:00:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2024-01-01T00:00:00")
+    private LocalDateTime lastModifiedAt;
+
+    public static MemberResponse from(Member member) {
+      return MemberResponse.builder()
+          .user(UserResponse.from(member.getId().getUser()))
+          .createdAt(member.getCreatedAt())
+          .lastModifiedAt(member.getLastModifiedAt())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/repository/MemberQueryRepository.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/repository/MemberQueryRepository.java
@@ -1,0 +1,81 @@
+package com.depth.learningcrew.domain.studygroup.repository;
+
+import static com.depth.learningcrew.domain.studygroup.entity.QMember.member;
+import static com.depth.learningcrew.domain.user.entity.QUser.user;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
+import com.depth.learningcrew.domain.studygroup.entity.Member;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepository {
+  private final JPAQueryFactory queryFactory;
+
+  public Page<MemberDto.MemberResponse> paginateStudyGroupMembers(
+      StudyGroup studyGroup,
+      MemberDto.SearchConditions searchConditions,
+      Pageable pageable) {
+
+    JPAQuery<Member> contentQuery = buildBaseQuery(studyGroup);
+    applySorting(contentQuery, searchConditions);
+
+    List<Member> results = contentQuery
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    Long totalCount = buildCountQuery(studyGroup)
+        .fetchOne();
+
+    List<MemberDto.MemberResponse> content = results.stream()
+        .map(MemberDto.MemberResponse::from)
+        .toList();
+
+    return new PageImpl<>(content, pageable, totalCount != null ? totalCount : 0L);
+  }
+
+  private JPAQuery<Member> buildBaseQuery(StudyGroup studyGroup) {
+    return queryFactory
+        .selectFrom(member)
+        .leftJoin(member.id.user, user).fetchJoin()
+        .where(member.id.studyGroup.eq(studyGroup));
+  }
+
+  private JPAQuery<Long> buildCountQuery(StudyGroup studyGroup) {
+    return queryFactory
+        .select(member.count())
+        .from(member)
+        .where(member.id.studyGroup.eq(studyGroup));
+  }
+
+  private void applySorting(JPAQuery<Member> query, MemberDto.SearchConditions searchConditions) {
+    String sort = searchConditions.getSort() != null ? searchConditions.getSort() : "created_at";
+    String order = searchConditions.getOrder() != null ? searchConditions.getOrder() : "desc";
+
+    if ("alphabet".equals(sort)) {
+      if ("asc".equals(order)) {
+        query.orderBy(member.id.user.nickname.asc());
+      } else {
+        query.orderBy(member.id.user.nickname.desc());
+      }
+    } else { // created_at (기본값)
+      if ("asc".equals(order)) {
+        query.orderBy(member.createdAt.asc());
+      } else {
+        query.orderBy(member.createdAt.desc());
+      }
+    }
+  }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/service/MemberService.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/service/MemberService.java
@@ -1,0 +1,49 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.repository.MemberQueryRepository;
+import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+  private final MemberQueryRepository memberQueryRepository;
+  private final StudyGroupRepository studyGroupRepository;
+
+  @Transactional(readOnly = true)
+  public PagedModel<MemberDto.MemberResponse> paginateStudyGroupMembers(
+      Long groupId,
+      MemberDto.SearchConditions searchConditions,
+      UserDetails userDetails,
+      Pageable pageable) {
+
+    StudyGroup studyGroup = studyGroupRepository.findById(groupId)
+        .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+    cannotViewIfNotOwner(userDetails, studyGroup);
+
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    return new PagedModel<>(result);
+  }
+
+  private static void cannotViewIfNotOwner(UserDetails userDetails, StudyGroup studyGroup) {
+    if(studyGroup.getOwner().getId().equals(userDetails.getUser().getId())) {
+        throw new RestException(ErrorCode.AUTH_FORBIDDEN);
+    }
+  }
+}

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/repository/MemberQueryRepositoryTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/repository/MemberQueryRepositoryTest.java
@@ -1,0 +1,396 @@
+package com.depth.learningcrew.domain.studygroup.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
+import com.depth.learningcrew.domain.studygroup.entity.Member;
+import com.depth.learningcrew.domain.studygroup.entity.MemberId;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.domain.user.entity.User;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class MemberQueryRepositoryTest {
+
+  @Autowired
+  private MemberQueryRepository memberQueryRepository;
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  private User owner;
+  private User member1;
+  private User member2;
+  private User member3;
+  private StudyGroup studyGroup;
+  private Member memberEntity1;
+  private Member memberEntity2;
+  private Member memberEntity3;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 사용자 생성
+    owner = User.builder()
+        .email("owner@example.com")
+        .password("password")
+        .nickname("owner")
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    member1 = User.builder()
+        .email("member1@example.com")
+        .password("password")
+        .nickname("alice")
+        .birthday(LocalDate.of(1991, 1, 1))
+        .gender(Gender.FEMALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    member2 = User.builder()
+        .email("member2@example.com")
+        .password("password")
+        .nickname("bob")
+        .birthday(LocalDate.of(1992, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    member3 = User.builder()
+        .email("member3@example.com")
+        .password("password")
+        .nickname("charlie")
+        .birthday(LocalDate.of(1993, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    // 스터디 그룹 생성
+    studyGroup = StudyGroup.builder()
+        .name("테스트 스터디 그룹")
+        .summary("테스트 스터디 그룹입니다.")
+        .maxMembers(10)
+        .memberCount(3)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(3))
+        .owner(owner)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    // 엔티티들을 데이터베이스에 저장
+    entityManager.persist(owner);
+    entityManager.persist(member1);
+    entityManager.persist(member2);
+    entityManager.persist(member3);
+    entityManager.persist(studyGroup);
+    entityManager.flush();
+
+    // 멤버 엔티티 생성 및 저장 (다른 시간으로 생성하여 정렬 테스트)
+    memberEntity1 = Member.builder()
+        .id(MemberId.of(member1, studyGroup))
+        .createdAt(LocalDateTime.now().minusDays(2))
+        .lastModifiedAt(LocalDateTime.now().minusDays(2))
+        .build();
+
+    memberEntity2 = Member.builder()
+        .id(MemberId.of(member2, studyGroup))
+        .createdAt(LocalDateTime.now().minusDays(1))
+        .lastModifiedAt(LocalDateTime.now().minusDays(1))
+        .build();
+
+    memberEntity3 = Member.builder()
+        .id(MemberId.of(member3, studyGroup))
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    entityManager.persist(memberEntity1);
+    entityManager.persist(memberEntity2);
+    entityManager.persist(memberEntity3);
+    entityManager.flush();
+  }
+
+  @Test
+  @DisplayName("스터디 그룹 멤버를 페이징하여 조회할 수 있다")
+  void paginateStudyGroupMembers_ShouldReturnPagedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(3);
+    assertThat(result.getTotalElements()).isEqualTo(3);
+    assertThat(result.getTotalPages()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("생성일 기준 내림차순으로 정렬된 결과를 반환한다")
+  void paginateStudyGroupMembers_WithCreatedAtDescSort_ShouldReturnSortedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(3);
+
+    // 최신 멤버가 먼저 나와야 함 (charlie -> bob -> alice)
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("charlie");
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("bob");
+    assertThat(result.getContent().get(2).getUser().getNickname()).isEqualTo("alice");
+  }
+
+  @Test
+  @DisplayName("생성일 기준 오름차순으로 정렬된 결과를 반환한다")
+  void paginateStudyGroupMembers_WithCreatedAtAscSort_ShouldReturnSortedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("asc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(3);
+
+    // 오래된 멤버가 먼저 나와야 함 (alice -> bob -> charlie)
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("alice");
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("bob");
+    assertThat(result.getContent().get(2).getUser().getNickname()).isEqualTo("charlie");
+  }
+
+  @Test
+  @DisplayName("알파벳 순으로 정렬된 결과를 반환한다")
+  void paginateStudyGroupMembers_WithAlphabetAscSort_ShouldReturnSortedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("alphabet")
+        .order("asc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(3);
+
+    // 알파벳 순 (alice -> bob -> charlie)
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("alice");
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("bob");
+    assertThat(result.getContent().get(2).getUser().getNickname()).isEqualTo("charlie");
+  }
+
+  @Test
+  @DisplayName("알파벳 역순으로 정렬된 결과를 반환한다")
+  void paginateStudyGroupMembers_WithAlphabetDescSort_ShouldReturnSortedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("alphabet")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(3);
+
+    // 알파벳 역순 (charlie -> bob -> alice)
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("charlie");
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("bob");
+    assertThat(result.getContent().get(2).getUser().getNickname()).isEqualTo("alice");
+  }
+
+  @Test
+  @DisplayName("페이징을 통해 멤버를 조회할 수 있다")
+  void paginateStudyGroupMembers_WithPaging_ShouldReturnPagedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 2); // 첫 번째 페이지, 2개씩
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getTotalElements()).isEqualTo(3);
+    assertThat(result.getTotalPages()).isEqualTo(2);
+
+    // 첫 번째 페이지: charlie, bob
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("charlie");
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("bob");
+  }
+
+  @Test
+  @DisplayName("두 번째 페이지를 조회할 수 있다")
+  void paginateStudyGroupMembers_WithSecondPage_ShouldReturnSecondPageResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(1, 2); // 두 번째 페이지, 2개씩
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getTotalElements()).isEqualTo(3);
+    assertThat(result.getTotalPages()).isEqualTo(2);
+
+    // 두 번째 페이지: alice
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("alice");
+  }
+
+  @Test
+  @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
+  void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
+    // given
+    MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, nullConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(3);
+
+    // 기본값은 created_at desc이므로 최신 멤버가 먼저 나와야 함
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("charlie");
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("bob");
+    assertThat(result.getContent().get(2).getUser().getNickname()).isEqualTo("alice");
+  }
+
+  @Test
+  @DisplayName("멤버 정보에 사용자 정보가 포함되어 있다")
+  void paginateStudyGroupMembers_ShouldIncludeUserInformation() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        studyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(3);
+
+    MemberDto.MemberResponse firstMember = result.getContent().get(0);
+    assertThat(firstMember.getUser()).isNotNull();
+    assertThat(firstMember.getUser().getId()).isEqualTo(member3.getId());
+    assertThat(firstMember.getUser().getEmail()).isEqualTo("member3@example.com");
+    assertThat(firstMember.getUser().getNickname()).isEqualTo("charlie");
+
+    assertThat(firstMember.getCreatedAt()).isNotNull();
+    assertThat(firstMember.getLastModifiedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("멤버가 없는 스터디 그룹도 정상적으로 처리된다")
+  void paginateStudyGroupMembers_WithNoMembers_ShouldReturnEmptyResults() {
+    // given
+    // 멤버가 없는 새로운 스터디 그룹 생성
+    StudyGroup emptyStudyGroup = StudyGroup.builder()
+        .name("빈 스터디 그룹")
+        .summary("멤버가 없는 스터디 그룹")
+        .maxMembers(10)
+        .memberCount(0)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(3))
+        .owner(owner)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    entityManager.persist(emptyStudyGroup);
+    entityManager.flush();
+
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<MemberDto.MemberResponse> result = memberQueryRepository.paginateStudyGroupMembers(
+        emptyStudyGroup, searchConditions, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).isEmpty();
+    assertThat(result.getTotalElements()).isEqualTo(0);
+    assertThat(result.getTotalPages()).isEqualTo(0);
+  }
+}

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceIntegrationTest.java
@@ -1,0 +1,371 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
+import com.depth.learningcrew.domain.studygroup.entity.Member;
+import com.depth.learningcrew.domain.studygroup.entity.MemberId;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class MemberServiceIntegrationTest {
+
+  @Autowired
+  private MemberService memberService;
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  private User owner;
+  private User member1;
+  private User member2;
+  private User otherUser;
+  private UserDetails ownerDetails;
+  private UserDetails otherUserDetails;
+  private StudyGroup studyGroup;
+  private Member memberEntity1;
+  private Member memberEntity2;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 사용자 생성
+    owner = User.builder()
+        .email("owner@example.com")
+        .password("password")
+        .nickname("owner")
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    member1 = User.builder()
+        .email("member1@example.com")
+        .password("password")
+        .nickname("member1")
+        .birthday(LocalDate.of(1991, 1, 1))
+        .gender(Gender.FEMALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    member2 = User.builder()
+        .email("member2@example.com")
+        .password("password")
+        .nickname("member2")
+        .birthday(LocalDate.of(1992, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    otherUser = User.builder()
+        .email("other@example.com")
+        .password("password")
+        .nickname("other")
+        .birthday(LocalDate.of(1995, 1, 1))
+        .gender(Gender.FEMALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    // 스터디 그룹 생성
+    studyGroup = StudyGroup.builder()
+        .name("테스트 스터디 그룹")
+        .summary("테스트 스터디 그룹입니다.")
+        .content("테스트 스터디 그룹 내용입니다.")
+        .maxMembers(10)
+        .memberCount(3)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(3))
+        .owner(owner)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    // 엔티티들을 데이터베이스에 저장
+    entityManager.persist(owner);
+    entityManager.persist(member1);
+    entityManager.persist(member2);
+    entityManager.persist(otherUser);
+    entityManager.persist(studyGroup);
+    entityManager.flush();
+
+    // 멤버 엔티티 생성 및 저장
+    memberEntity1 = Member.builder()
+        .id(MemberId.of(member1, studyGroup))
+        .createdAt(LocalDateTime.now().minusDays(1))
+        .lastModifiedAt(LocalDateTime.now().minusDays(1))
+        .build();
+
+    memberEntity2 = Member.builder()
+        .id(MemberId.of(member2, studyGroup))
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    entityManager.persist(memberEntity1);
+    entityManager.persist(memberEntity2);
+    entityManager.flush();
+
+    // UserDetails 생성
+    ownerDetails = UserDetails.builder()
+        .user(owner)
+        .build();
+
+    otherUserDetails = UserDetails.builder()
+        .user(otherUser)
+        .build();
+  }
+
+  @Test
+  @DisplayName("스터디 그룹 멤버를 성공적으로 페이징하여 조회할 수 있다")
+  void paginateStudyGroupMembers_ShouldReturnPagedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2"); // 최신 멤버
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1"); // 이전 멤버
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
+  void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when & then
+    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+        999L, searchConditions, ownerDetails, pageable))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
+  void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when & then
+    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), searchConditions, otherUserDetails, pageable))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("알파벳 순으로 멤버를 정렬하여 조회할 수 있다")
+  void paginateStudyGroupMembers_WithAlphabetSort_ShouldReturnSortedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("alphabet")
+        .order("asc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1"); // 알파벳 순
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member2");
+  }
+
+  @Test
+  @DisplayName("알파벳 역순으로 멤버를 정렬하여 조회할 수 있다")
+  void paginateStudyGroupMembers_WithAlphabetDescSort_ShouldReturnSortedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("alphabet")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2"); // 알파벳 역순
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1");
+  }
+
+  @Test
+  @DisplayName("페이징을 통해 멤버를 조회할 수 있다")
+  void paginateStudyGroupMembers_WithPaging_ShouldReturnPagedResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 1); // 첫 번째 페이지, 1개씩
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2"); // 최신 멤버
+  }
+
+  @Test
+  @DisplayName("두 번째 페이지를 조회할 수 있다")
+  void paginateStudyGroupMembers_WithSecondPage_ShouldReturnSecondPageResults() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(1, 1); // 두 번째 페이지, 1개씩
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1"); // 이전 멤버
+  }
+
+  @Test
+  @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
+  void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
+    // given
+    MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), nullConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+    // 기본값은 created_at desc이므로 최신 멤버가 먼저 나와야 함
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2");
+    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1");
+  }
+
+  @Test
+  @DisplayName("멤버가 없는 스터디 그룹도 정상적으로 처리된다")
+  void paginateStudyGroupMembers_WithNoMembers_ShouldReturnEmptyResults() {
+    // given
+    // 멤버가 없는 새로운 스터디 그룹 생성
+    StudyGroup emptyStudyGroup = StudyGroup.builder()
+        .name("빈 스터디 그룹")
+        .summary("멤버가 없는 스터디 그룹")
+        .maxMembers(10)
+        .memberCount(0)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(3))
+        .owner(owner)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    entityManager.persist(emptyStudyGroup);
+    entityManager.flush();
+
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        emptyStudyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("멤버 정보에 사용자 정보가 포함되어 있다")
+  void paginateStudyGroupMembers_ShouldIncludeUserInformation() {
+    // given
+    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+
+    MemberDto.MemberResponse firstMember = result.getContent().get(0);
+    assertThat(firstMember.getUser()).isNotNull();
+    assertThat(firstMember.getUser().getId()).isEqualTo(member2.getId());
+    assertThat(firstMember.getUser().getEmail()).isEqualTo("member2@example.com");
+    assertThat(firstMember.getUser().getNickname()).isEqualTo("member2");
+
+    assertThat(firstMember.getCreatedAt()).isNotNull();
+    assertThat(firstMember.getLastModifiedAt()).isNotNull();
+  }
+}

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceTest.java
@@ -1,0 +1,325 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
+
+import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.repository.MemberQueryRepository;
+import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+  @Mock
+  private MemberQueryRepository memberQueryRepository;
+
+  @Mock
+  private StudyGroupRepository studyGroupRepository;
+
+  @InjectMocks
+  private MemberService memberService;
+
+  private User testUser;
+  private UserDetails testUserDetails;
+  private StudyGroup testStudyGroup;
+  private MemberDto.SearchConditions searchConditions;
+  private Pageable pageable;
+  private MemberDto.MemberResponse testMemberResponse;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트 사용자 설정
+    testUser = User.builder()
+        .id(1L)
+        .email("test@example.com")
+        .password("password")
+        .nickname("testUser")
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    testUserDetails = UserDetails.builder()
+        .user(testUser)
+        .build();
+
+    // 테스트 스터디 그룹 설정
+    testStudyGroup = StudyGroup.builder()
+        .id(1L)
+        .name("테스트 스터디 그룹")
+        .summary("테스트 스터디 그룹입니다.")
+        .maxMembers(10)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(3))
+        .owner(testUser)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    // 테스트 멤버 응답 DTO 설정
+    testMemberResponse = MemberDto.MemberResponse.builder()
+        .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
+            .id(testUser.getId())
+            .email(testUser.getEmail())
+            .nickname(testUser.getNickname())
+            .build())
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    // 검색 조건 설정
+    searchConditions = MemberDto.SearchConditions.builder()
+        .sort("created_at")
+        .order("desc")
+        .build();
+
+    // 페이징 설정
+    pageable = PageRequest.of(0, 10);
+  }
+
+  @Test
+  @DisplayName("스터디 그룹 멤버를 페이징하여 조회할 수 있다")
+  void paginateStudyGroupMembers_ShouldReturnPagedResults() {
+    // given
+    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+        List.of(testMemberResponse), pageable, 1L);
+
+    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+    when(memberQueryRepository.paginateStudyGroupMembers(
+        eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+        .thenReturn(mockPage);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        1L, searchConditions, testUserDetails, pageable);
+
+    // then
+    verify(studyGroupRepository, times(1)).findById(1L);
+    verify(memberQueryRepository, times(1))
+        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(testUser.getId());
+    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo(testUser.getNickname());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
+  void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
+    // given
+    when(studyGroupRepository.findById(999L)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+        999L, searchConditions, testUserDetails, pageable))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
+  void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
+    // given
+    User otherUser = User.builder()
+        .id(2L)
+        .email("other@example.com")
+        .nickname("otherUser")
+        .build();
+
+    UserDetails otherUserDetails = UserDetails.builder()
+        .user(otherUser)
+        .build();
+
+    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+
+    // when & then
+    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+        1L, searchConditions, otherUserDetails, pageable))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("빈 검색 결과가 있을 때도 정상적으로 PagedModel을 반환한다")
+  void paginateStudyGroupMembers_WithEmptyResults_ShouldReturnEmptyPagedModel() {
+    // given
+    Page<MemberDto.MemberResponse> emptyPage = new PageImpl<>(
+        List.of(), pageable, 0L);
+
+    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+    when(memberQueryRepository.paginateStudyGroupMembers(
+        eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+        .thenReturn(emptyPage);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        1L, searchConditions, testUserDetails, pageable);
+
+    // then
+    verify(studyGroupRepository, times(1)).findById(1L);
+    verify(memberQueryRepository, times(1))
+        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("다양한 정렬 조건으로 멤버를 조회할 수 있다")
+  void paginateStudyGroupMembers_WithDifferentSortConditions_ShouldWorkCorrectly() {
+    // given
+    MemberDto.SearchConditions alphabetSortConditions = MemberDto.SearchConditions.builder()
+        .sort("alphabet")
+        .order("asc")
+        .build();
+
+    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+        List.of(testMemberResponse), pageable, 1L);
+
+    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+    when(memberQueryRepository.paginateStudyGroupMembers(
+        eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable)))
+        .thenReturn(mockPage);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        1L, alphabetSortConditions, testUserDetails, pageable);
+
+    // then
+    verify(studyGroupRepository, times(1)).findById(1L);
+    verify(memberQueryRepository, times(1))
+        .paginateStudyGroupMembers(eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable));
+
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("다양한 페이징 설정으로 멤버를 조회할 수 있다")
+  void paginateStudyGroupMembers_WithDifferentPageable_ShouldWorkCorrectly() {
+    // given
+    Pageable customPageable = PageRequest.of(1, 5); // 두 번째 페이지, 5개씩
+
+    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+        List.of(testMemberResponse), customPageable, 1L);
+
+    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+    when(memberQueryRepository.paginateStudyGroupMembers(
+        eq(testStudyGroup), eq(searchConditions), eq(customPageable)))
+        .thenReturn(mockPage);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        1L, searchConditions, testUserDetails, customPageable);
+
+    // then
+    verify(studyGroupRepository, times(1)).findById(1L);
+    verify(memberQueryRepository, times(1))
+        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(customPageable));
+
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("여러 명의 멤버가 있을 때 모든 결과를 반환한다")
+  void paginateStudyGroupMembers_WithMultipleResults_ShouldReturnAllResults() {
+    // given
+    User secondUser = User.builder()
+        .id(2L)
+        .email("second@example.com")
+        .nickname("secondUser")
+        .build();
+
+    MemberDto.MemberResponse secondMemberResponse = MemberDto.MemberResponse.builder()
+        .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
+            .id(secondUser.getId())
+            .email(secondUser.getEmail())
+            .nickname(secondUser.getNickname())
+            .build())
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+        List.of(testMemberResponse, secondMemberResponse), pageable, 2L);
+
+    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+    when(memberQueryRepository.paginateStudyGroupMembers(
+        eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+        .thenReturn(mockPage);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        1L, searchConditions, testUserDetails, pageable);
+
+    // then
+    verify(studyGroupRepository, times(1)).findById(1L);
+    verify(memberQueryRepository, times(1))
+        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(1L);
+    assertThat(result.getContent().get(1).getUser().getId()).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
+  void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
+    // given
+    MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
+
+    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+        List.of(testMemberResponse), pageable, 1L);
+
+    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+    when(memberQueryRepository.paginateStudyGroupMembers(
+        eq(testStudyGroup), eq(nullConditions), eq(pageable)))
+        .thenReturn(mockPage);
+
+    // when
+    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+        1L, nullConditions, testUserDetails, pageable);
+
+    // then
+    verify(studyGroupRepository, times(1)).findById(1L);
+    verify(memberQueryRepository, times(1))
+        .paginateStudyGroupMembers(eq(testStudyGroup), eq(nullConditions), eq(pageable));
+
+    assertThat(result).isNotNull();
+    assertThat(result.getContent()).hasSize(1);
+  }
+}


### PR DESCRIPTION
- MemberController, MemberDto, MemberQueryRepository, MemberService 및 관련 테스트 파일 추가
- 스터디 그룹의 멤버를 페이징하여 조회할 수 있는 기능 구현
- 멤버 검색 조건에 따른 정렬 기능 추가 (생성일, 알파벳 순)

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
