### PR TITLE
LNIT-37-스터디-그룹-멤버-추방-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/MemberController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/MemberController.java
@@ -4,11 +4,14 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
@@ -36,6 +39,18 @@ public class MemberController {
       @AuthenticationPrincipal UserDetails userDetails) {
 
     return memberService.paginateStudyGroupMembers(groupId, searchConditions, userDetails, pageable);
+  }
+
+  @DeleteMapping("/{userId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(summary = "스터디 그룹 멤버 추방", description = "그룹의 owner 권한을 가진 사용자가 스터디 그룹의 멤버를 추방합니다.")
+  @ApiResponse(responseCode = "204", description = "멤버 추방 성공")
+  @ApiResponse(responseCode = "403", description = "권한 없음")
+  @ApiResponse(responseCode = "404", description = "스터디 그룹 또는 사용자를 찾을 수 없음")
+  public void expelMember(@PathVariable Long groupId, @PathVariable Long userId,
+      @AuthenticationPrincipal UserDetails userDetails) {
+
+    memberService.expelMember(groupId, userId, userDetails);
   }
 
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyGroup.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyGroup.java
@@ -12,7 +12,20 @@ import com.depth.learningcrew.system.exception.model.ErrorCode;
 import com.depth.learningcrew.system.exception.model.RestException;
 import com.depth.learningcrew.system.security.model.UserDetails;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -79,7 +92,6 @@ public class StudyGroup extends TimeStampedEntity {
     @Builder.Default
     private List<Dibs> dibsList = new ArrayList<>();
 
-
     public void canUpdateBy(UserDetails user) {
         if (user.getUser().getRole().equals(Role.ADMIN)) {
             return;
@@ -97,6 +109,12 @@ public class StudyGroup extends TimeStampedEntity {
         if (!this.categories.contains(category)) {
             this.categories.add(category);
             category.getStudyGroups().add(this);
+        }
+    }
+
+    public void decreaseMemberCount() {
+        if (this.memberCount > 0) {
+            this.memberCount--;
         }
     }
 }

--- a/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
+++ b/src/main/java/com/depth/learningcrew/system/exception/model/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     STUDY_GROUP_APPLICATION_ALREADY_APPROVED(400, "이미 수락된 신청입니다."),
     STUDY_GROUP_APPLICATION_ALREADY_REJECTED(400, "이미 거절된 신청입니다."),
     STUDY_GROUP_NOT_FOUND(404, "스터디 그룹을 찾을 수 없습니다."),
+    STUDY_GROUP_OWNER_CANNOT_BE_EXPELLED(400, "스터디 그룹의 소유자는 추방할 수 없습니다."),
 
     // Other
     INTERNAL_SERVER_ERROR(500, "오류가 발생했습니다."),;

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,338 +36,504 @@ import jakarta.persistence.PersistenceContext;
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class MemberServiceIntegrationTest {
 
-  @Autowired
-  private MemberService memberService;
+    @Autowired
+    private MemberService memberService;
 
-  @PersistenceContext
-  private EntityManager entityManager;
+    @PersistenceContext
+    private EntityManager entityManager;
 
-  private User owner;
-  private User member1;
-  private User member2;
-  private User otherUser;
-  private UserDetails ownerDetails;
-  private UserDetails otherUserDetails;
-  private StudyGroup studyGroup;
-  private Member memberEntity1;
-  private Member memberEntity2;
+    private static volatile long testCounter = 0;
+    private long currentTestId;
 
-  @BeforeEach
-  void setUp() {
-    // 테스트 사용자 생성
-    owner = User.builder()
-        .email("owner@example.com")
-        .password("password")
-        .nickname("owner")
-        .birthday(LocalDate.of(1990, 1, 1))
-        .gender(Gender.MALE)
-        .role(Role.USER)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+    private User owner;
+    private User member1;
+    private User member2;
+    private User otherUser;
+    private UserDetails ownerDetails;
+    private UserDetails otherUserDetails;
+    private StudyGroup studyGroup;
+    private Member memberEntity1;
+    private Member memberEntity2;
 
-    member1 = User.builder()
-        .email("member1@example.com")
-        .password("password")
-        .nickname("member1")
-        .birthday(LocalDate.of(1991, 1, 1))
-        .gender(Gender.FEMALE)
-        .role(Role.USER)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+    @BeforeEach
+    void setUp() {
+        // 각 테스트마다 고유한 ID 생성
+        currentTestId = ++testCounter;
 
-    member2 = User.builder()
-        .email("member2@example.com")
-        .password("password")
-        .nickname("member2")
-        .birthday(LocalDate.of(1992, 1, 1))
-        .gender(Gender.MALE)
-        .role(Role.USER)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+        // 기존 데이터 완전 정리 - 외래키 제약조건을 고려한 순서
+        entityManager.createQuery("DELETE FROM Member m").executeUpdate();
+        entityManager.createQuery("DELETE FROM Application a").executeUpdate();
+        entityManager.createQuery("DELETE FROM Dibs d").executeUpdate();
+        entityManager.createQuery("DELETE FROM StudyGroup s").executeUpdate();
+        entityManager.createQuery("DELETE FROM User u").executeUpdate();
+        entityManager.flush();
+        entityManager.clear(); // 영속성 컨텍스트 완전 초기화
 
-    otherUser = User.builder()
-        .email("other@example.com")
-        .password("password")
-        .nickname("other")
-        .birthday(LocalDate.of(1995, 1, 1))
-        .gender(Gender.FEMALE)
-        .role(Role.USER)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+        // 테스트 사용자 생성 - 고유한 값 사용
+        String testId = String.valueOf(currentTestId);
 
-    // 스터디 그룹 생성
-    studyGroup = StudyGroup.builder()
-        .name("테스트 스터디 그룹")
-        .summary("테스트 스터디 그룹입니다.")
-        .content("테스트 스터디 그룹 내용입니다.")
-        .maxMembers(10)
-        .memberCount(3)
-        .currentStep(1)
-        .startDate(LocalDate.now())
-        .endDate(LocalDate.now().plusMonths(3))
-        .owner(owner)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+        owner = User.builder()
+                .email("owner_" + testId + "@test.com")
+                .password("password")
+                .nickname("owner_" + testId)
+                .birthday(LocalDate.of(1990, 1, 1))
+                .gender(Gender.MALE)
+                .role(Role.USER)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // 엔티티들을 데이터베이스에 저장
-    entityManager.persist(owner);
-    entityManager.persist(member1);
-    entityManager.persist(member2);
-    entityManager.persist(otherUser);
-    entityManager.persist(studyGroup);
-    entityManager.flush();
+        member1 = User.builder()
+                .email("member1_" + testId + "@test.com")
+                .password("password")
+                .nickname("member1_" + testId)
+                .birthday(LocalDate.of(1991, 1, 1))
+                .gender(Gender.FEMALE)
+                .role(Role.USER)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // 멤버 엔티티 생성 및 저장
-    memberEntity1 = Member.builder()
-        .id(MemberId.of(member1, studyGroup))
-        .createdAt(LocalDateTime.now().minusDays(1))
-        .lastModifiedAt(LocalDateTime.now().minusDays(1))
-        .build();
+        member2 = User.builder()
+                .email("member2_" + testId + "@test.com")
+                .password("password")
+                .nickname("member2_" + testId)
+                .birthday(LocalDate.of(1992, 1, 1))
+                .gender(Gender.MALE)
+                .role(Role.USER)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    memberEntity2 = Member.builder()
-        .id(MemberId.of(member2, studyGroup))
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+        otherUser = User.builder()
+                .email("other_" + testId + "@test.com")
+                .password("password")
+                .nickname("other_" + testId)
+                .birthday(LocalDate.of(1995, 1, 1))
+                .gender(Gender.FEMALE)
+                .role(Role.USER)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    entityManager.persist(memberEntity1);
-    entityManager.persist(memberEntity2);
-    entityManager.flush();
+        // 스터디 그룹 생성
+        studyGroup = StudyGroup.builder()
+                .name("테스트 스터디 그룹_" + testId)
+                .summary("테스트 스터디 그룹입니다.")
+                .content("테스트 스터디 그룹 내용입니다.")
+                .maxMembers(10)
+                .memberCount(3)
+                .currentStep(1)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusMonths(3))
+                .owner(owner)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // UserDetails 생성
-    ownerDetails = UserDetails.builder()
-        .user(owner)
-        .build();
+        // 엔티티들을 데이터베이스에 저장
+        entityManager.persist(owner);
+        entityManager.persist(member1);
+        entityManager.persist(member2);
+        entityManager.persist(otherUser);
+        entityManager.persist(studyGroup);
+        entityManager.flush();
 
-    otherUserDetails = UserDetails.builder()
-        .user(otherUser)
-        .build();
-  }
+        // 멤버 엔티티 생성 및 저장
+        memberEntity1 = Member.builder()
+                .id(MemberId.of(member1, studyGroup))
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .lastModifiedAt(LocalDateTime.now().minusDays(1))
+                .build();
 
-  @Test
-  @DisplayName("스터디 그룹 멤버를 성공적으로 페이징하여 조회할 수 있다")
-  void paginateStudyGroupMembers_ShouldReturnPagedResults() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 10);
+        memberEntity2 = Member.builder()
+                .id(MemberId.of(member2, studyGroup))
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        entityManager.persist(memberEntity1);
+        entityManager.persist(memberEntity2);
+        entityManager.flush();
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(2);
-    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2"); // 최신 멤버
-    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1"); // 이전 멤버
-  }
+        // UserDetails 생성
+        ownerDetails = UserDetails.builder()
+                .user(owner)
+                .build();
 
-  @Test
-  @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
-  void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 10);
+        otherUserDetails = UserDetails.builder()
+                .user(otherUser)
+                .build();
+    }
 
-    // when & then
-    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-        999L, searchConditions, ownerDetails, pageable))
-        .isInstanceOf(RestException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-  }
+    @AfterEach
+    void tearDown() {
+        // 영속성 컨텍스트 초기화
+        if (entityManager != null) {
+            entityManager.clear();
+        }
+    }
 
-  @Test
-  @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
-  void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 10);
+    @Test
+    @DisplayName("스터디 그룹 멤버를 성공적으로 페이징하여 조회할 수 있다")
+    void paginateStudyGroupMembers_ShouldReturnPagedResults() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
 
-    // when & then
-    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), searchConditions, otherUserDetails, pageable))
-        .isInstanceOf(RestException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
-  }
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-  @Test
-  @DisplayName("알파벳 순으로 멤버를 정렬하여 조회할 수 있다")
-  void paginateStudyGroupMembers_WithAlphabetSort_ShouldReturnSortedResults() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("alphabet")
-        .order("asc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 10);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 최신 멤버
+        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 이전 멤버
+    }
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+    @Test
+    @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
+    void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(2);
-    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1"); // 알파벳 순
-    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member2");
-  }
+        // when & then
+        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                999L, searchConditions, ownerDetails, pageable))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+    }
 
-  @Test
-  @DisplayName("알파벳 역순으로 멤버를 정렬하여 조회할 수 있다")
-  void paginateStudyGroupMembers_WithAlphabetDescSort_ShouldReturnSortedResults() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("alphabet")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 10);
+    @Test
+    @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
+    void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        // when & then
+        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), searchConditions, otherUserDetails, pageable))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+    }
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(2);
-    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2"); // 알파벳 역순
-    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1");
-  }
+    @Test
+    @DisplayName("알파벳 순으로 멤버를 정렬하여 조회할 수 있다")
+    void paginateStudyGroupMembers_WithAlphabetSort_ShouldReturnSortedResults() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("alphabet")
+                .order("asc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
 
-  @Test
-  @DisplayName("페이징을 통해 멤버를 조회할 수 있다")
-  void paginateStudyGroupMembers_WithPaging_ShouldReturnPagedResults() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 1); // 첫 번째 페이지, 1개씩
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 알파벳 순
+        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member2_" + currentTestId);
+    }
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(1);
-    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2"); // 최신 멤버
-  }
+    @Test
+    @DisplayName("알파벳 역순으로 멤버를 정렬하여 조회할 수 있다")
+    void paginateStudyGroupMembers_WithAlphabetDescSort_ShouldReturnSortedResults() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("alphabet")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
 
-  @Test
-  @DisplayName("두 번째 페이지를 조회할 수 있다")
-  void paginateStudyGroupMembers_WithSecondPage_ShouldReturnSecondPageResults() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(1, 1); // 두 번째 페이지, 1개씩
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 알파벳 역순
+        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId);
+    }
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(1);
-    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1"); // 이전 멤버
-  }
+    @Test
+    @DisplayName("페이징을 통해 멤버를 조회할 수 있다")
+    void paginateStudyGroupMembers_WithPaging_ShouldReturnPagedResults() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 1); // 첫 번째 페이지, 1개씩
 
-  @Test
-  @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
-  void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
-    // given
-    MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
-    Pageable pageable = PageRequest.of(0, 10);
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), nullConditions, ownerDetails, pageable);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 최신 멤버
+    }
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(2);
-    // 기본값은 created_at desc이므로 최신 멤버가 먼저 나와야 함
-    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2");
-    assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1");
-  }
+    @Test
+    @DisplayName("두 번째 페이지를 조회할 수 있다")
+    void paginateStudyGroupMembers_WithSecondPage_ShouldReturnSecondPageResults() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(1, 1); // 두 번째 페이지, 1개씩
 
-  @Test
-  @DisplayName("멤버가 없는 스터디 그룹도 정상적으로 처리된다")
-  void paginateStudyGroupMembers_WithNoMembers_ShouldReturnEmptyResults() {
-    // given
-    // 멤버가 없는 새로운 스터디 그룹 생성
-    StudyGroup emptyStudyGroup = StudyGroup.builder()
-        .name("빈 스터디 그룹")
-        .summary("멤버가 없는 스터디 그룹")
-        .maxMembers(10)
-        .memberCount(0)
-        .currentStep(1)
-        .startDate(LocalDate.now())
-        .endDate(LocalDate.now().plusMonths(3))
-        .owner(owner)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    entityManager.persist(emptyStudyGroup);
-    entityManager.flush();
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 이전 멤버
+    }
 
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 10);
+    @Test
+    @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
+    void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
+        // given
+        MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
+        Pageable pageable = PageRequest.of(0, 10);
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        emptyStudyGroup.getId(), searchConditions, ownerDetails, pageable);
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), nullConditions, ownerDetails, pageable);
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).isEmpty();
-  }
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        // 기본값은 created_at desc이므로 최신 멤버가 먼저 나와야 함
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId);
+        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId);
+    }
 
-  @Test
-  @DisplayName("멤버 정보에 사용자 정보가 포함되어 있다")
-  void paginateStudyGroupMembers_ShouldIncludeUserInformation() {
-    // given
-    MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
-    Pageable pageable = PageRequest.of(0, 10);
+    @Test
+    @DisplayName("멤버가 없는 스터디 그룹도 정상적으로 처리된다")
+    void paginateStudyGroupMembers_WithNoMembers_ShouldReturnEmptyResults() {
+        // given
+        // 멤버가 없는 새로운 스터디 그룹 생성
+        StudyGroup emptyStudyGroup = StudyGroup.builder()
+                .name("빈 스터디 그룹_" + currentTestId)
+                .summary("멤버가 없는 스터디 그룹")
+                .maxMembers(10)
+                .memberCount(0)
+                .currentStep(1)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusMonths(3))
+                .owner(owner)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        entityManager.persist(emptyStudyGroup);
+        entityManager.flush();
 
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(2);
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
 
-    MemberDto.MemberResponse firstMember = result.getContent().get(0);
-    assertThat(firstMember.getUser()).isNotNull();
-    assertThat(firstMember.getUser().getId()).isEqualTo(member2.getId());
-    assertThat(firstMember.getUser().getEmail()).isEqualTo("member2@example.com");
-    assertThat(firstMember.getUser().getNickname()).isEqualTo("member2");
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                emptyStudyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    assertThat(firstMember.getCreatedAt()).isNotNull();
-    assertThat(firstMember.getLastModifiedAt()).isNotNull();
-  }
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("멤버 정보에 사용자 정보가 포함되어 있다")
+    void paginateStudyGroupMembers_ShouldIncludeUserInformation() {
+        // given
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                studyGroup.getId(), searchConditions, ownerDetails, pageable);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+
+        MemberDto.MemberResponse firstMember = result.getContent().get(0);
+        assertThat(firstMember.getUser()).isNotNull();
+        assertThat(firstMember.getUser().getId()).isEqualTo(member2.getId());
+        assertThat(firstMember.getUser().getEmail()).isEqualTo("member2_" + currentTestId + "@test.com");
+        assertThat(firstMember.getUser().getNickname()).isEqualTo("member2_" + currentTestId);
+
+        assertThat(firstMember.getCreatedAt()).isNotNull();
+        assertThat(firstMember.getLastModifiedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - 성공")
+    void expelMember_Success() {
+        // given
+        Long groupId = studyGroup.getId();
+        Long userId = member1.getId();
+
+        // when
+        memberService.expelMember(groupId, userId, ownerDetails);
+
+        // then
+        // 멤버가 실제로 삭제되었는지 확인
+        Member deletedMember = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+        assertThat(deletedMember).isNull();
+
+        // 스터디 그룹의 멤버 수가 감소했는지 확인
+        StudyGroup updatedStudyGroup = entityManager.find(StudyGroup.class, groupId);
+        assertThat(updatedStudyGroup.getMemberCount()).isEqualTo(2); // 3 -> 2
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - owner가 아닌 경우 실패")
+    void expelMember_NotOwner_ThrowsException() {
+        // given
+        Long groupId = studyGroup.getId();
+        Long userId = member1.getId();
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, otherUserDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+
+        // 멤버가 삭제되지 않았는지 확인
+        Member member = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+        assertThat(member).isNotNull();
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - owner 자신을 추방하려는 경우 실패")
+    void expelMember_ExpelOwner_ThrowsException() {
+        // given
+        Long groupId = studyGroup.getId();
+        Long userId = owner.getId();
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STUDY_GROUP_OWNER_CANNOT_BE_EXPELLED);
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - 존재하지 않는 스터디 그룹 실패")
+    void expelMember_NonExistentStudyGroup_ThrowsException() {
+        // given
+        Long groupId = 999L;
+        Long userId = member1.getId();
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - 존재하지 않는 사용자 실패")
+    void expelMember_NonExistentUser_ThrowsException() {
+        // given
+        Long groupId = studyGroup.getId();
+        Long userId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - 그룹에 속하지 않은 사용자 실패")
+    void expelMember_UserNotInGroup_ThrowsException() {
+        // given
+        Long groupId = studyGroup.getId();
+        Long userId = otherUser.getId();
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("여러 멤버를 순차적으로 추방할 수 있다")
+    void expelMultipleMembers_Success() {
+        // given
+        Long groupId = studyGroup.getId();
+
+        // when - 첫 번째 멤버 추방
+        memberService.expelMember(groupId, member1.getId(), ownerDetails);
+
+        // then - 첫 번째 멤버 추방 확인
+        Member deletedMember1 = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+        assertThat(deletedMember1).isNull();
+
+        StudyGroup studyGroupAfterFirstExpel = entityManager.find(StudyGroup.class, groupId);
+        assertThat(studyGroupAfterFirstExpel.getMemberCount()).isEqualTo(2);
+
+        // when - 두 번째 멤버 추방
+        memberService.expelMember(groupId, member2.getId(), ownerDetails);
+
+        // then - 두 번째 멤버 추방 확인
+        Member deletedMember2 = entityManager.find(Member.class, MemberId.of(member2, studyGroup));
+        assertThat(deletedMember2).isNull();
+
+        StudyGroup studyGroupAfterSecondExpel = entityManager.find(StudyGroup.class, groupId);
+        assertThat(studyGroupAfterSecondExpel.getMemberCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("멤버 추방 후 멤버 조회에서 제외된다")
+    void expelMember_ShouldBeExcludedFromMemberList() {
+        // given
+        Long groupId = studyGroup.getId();
+        Long userId = member1.getId();
+
+        // when - 멤버 추방
+        memberService.expelMember(groupId, userId, ownerDetails);
+
+        // then - 멤버 조회에서 제외되었는지 확인
+        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                groupId, searchConditions, ownerDetails, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(member2.getId());
+    }
 }

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceTest.java
@@ -3,6 +3,7 @@ package com.depth.learningcrew.domain.studygroup.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,12 +27,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 
 import com.depth.learningcrew.domain.studygroup.dto.MemberDto;
+import com.depth.learningcrew.domain.studygroup.entity.Member;
 import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
 import com.depth.learningcrew.domain.studygroup.repository.MemberQueryRepository;
+import com.depth.learningcrew.domain.studygroup.repository.MemberRepository;
 import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
 import com.depth.learningcrew.domain.user.entity.Gender;
 import com.depth.learningcrew.domain.user.entity.Role;
 import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.domain.user.repository.UserRepository;
 import com.depth.learningcrew.system.exception.model.ErrorCode;
 import com.depth.learningcrew.system.exception.model.RestException;
 import com.depth.learningcrew.system.security.model.UserDetails;
@@ -39,287 +43,411 @@ import com.depth.learningcrew.system.security.model.UserDetails;
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-  @Mock
-  private MemberQueryRepository memberQueryRepository;
+    @Mock
+    private MemberQueryRepository memberQueryRepository;
 
-  @Mock
-  private StudyGroupRepository studyGroupRepository;
+    @Mock
+    private MemberRepository memberRepository;
 
-  @InjectMocks
-  private MemberService memberService;
+    @Mock
+    private StudyGroupRepository studyGroupRepository;
 
-  private User testUser;
-  private UserDetails testUserDetails;
-  private StudyGroup testStudyGroup;
-  private MemberDto.SearchConditions searchConditions;
-  private Pageable pageable;
-  private MemberDto.MemberResponse testMemberResponse;
+    @Mock
+    private UserRepository userRepository;
 
-  @BeforeEach
-  void setUp() {
-    // 테스트 사용자 설정
-    testUser = User.builder()
-        .id(1L)
-        .email("test@example.com")
-        .password("password")
-        .nickname("testUser")
-        .birthday(LocalDate.of(1990, 1, 1))
-        .gender(Gender.MALE)
-        .role(Role.USER)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+    @InjectMocks
+    private MemberService memberService;
 
-    testUserDetails = UserDetails.builder()
-        .user(testUser)
-        .build();
+    private User testUser;
+    private UserDetails testUserDetails;
+    private StudyGroup testStudyGroup;
+    private MemberDto.SearchConditions searchConditions;
+    private Pageable pageable;
+    private MemberDto.MemberResponse testMemberResponse;
 
-    // 테스트 스터디 그룹 설정
-    testStudyGroup = StudyGroup.builder()
-        .id(1L)
-        .name("테스트 스터디 그룹")
-        .summary("테스트 스터디 그룹입니다.")
-        .maxMembers(10)
-        .startDate(LocalDate.now())
-        .endDate(LocalDate.now().plusMonths(3))
-        .owner(testUser)
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 설정
+        testUser = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .password("password")
+                .nickname("testUser")
+                .birthday(LocalDate.of(1990, 1, 1))
+                .gender(Gender.MALE)
+                .role(Role.USER)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // 테스트 멤버 응답 DTO 설정
-    testMemberResponse = MemberDto.MemberResponse.builder()
-        .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
-            .id(testUser.getId())
-            .email(testUser.getEmail())
-            .nickname(testUser.getNickname())
-            .build())
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+        testUserDetails = UserDetails.builder()
+                .user(testUser)
+                .build();
 
-    // 검색 조건 설정
-    searchConditions = MemberDto.SearchConditions.builder()
-        .sort("created_at")
-        .order("desc")
-        .build();
+        // 테스트 스터디 그룹 설정
+        testStudyGroup = StudyGroup.builder()
+                .id(1L)
+                .name("테스트 스터디 그룹")
+                .summary("테스트 스터디 그룹입니다.")
+                .maxMembers(10)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusMonths(3))
+                .owner(testUser)
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // 페이징 설정
-    pageable = PageRequest.of(0, 10);
-  }
+        // 테스트 멤버 응답 DTO 설정
+        testMemberResponse = MemberDto.MemberResponse.builder()
+                .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
+                        .id(testUser.getId())
+                        .email(testUser.getEmail())
+                        .nickname(testUser.getNickname())
+                        .build())
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-  @Test
-  @DisplayName("스터디 그룹 멤버를 페이징하여 조회할 수 있다")
-  void paginateStudyGroupMembers_ShouldReturnPagedResults() {
-    // given
-    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-        List.of(testMemberResponse), pageable, 1L);
+        // 검색 조건 설정
+        searchConditions = MemberDto.SearchConditions.builder()
+                .sort("created_at")
+                .order("desc")
+                .build();
 
-    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-    when(memberQueryRepository.paginateStudyGroupMembers(
-        eq(testStudyGroup), eq(searchConditions), eq(pageable)))
-        .thenReturn(mockPage);
+        // 페이징 설정
+        pageable = PageRequest.of(0, 10);
+    }
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        1L, searchConditions, testUserDetails, pageable);
+    @Test
+    @DisplayName("스터디 그룹 멤버를 페이징하여 조회할 수 있다")
+    void paginateStudyGroupMembers_ShouldReturnPagedResults() {
+        // given
+        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                List.of(testMemberResponse), pageable, 1L);
 
-    // then
-    verify(studyGroupRepository, times(1)).findById(1L);
-    verify(memberQueryRepository, times(1))
-        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+        when(memberQueryRepository.paginateStudyGroupMembers(
+                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+                .thenReturn(mockPage);
 
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(1);
-    assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(testUser.getId());
-    assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo(testUser.getNickname());
-  }
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                1L, searchConditions, testUserDetails, pageable);
 
-  @Test
-  @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
-  void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
-    // given
-    when(studyGroupRepository.findById(999L)).thenReturn(Optional.empty());
+        // then
+        verify(studyGroupRepository, times(1)).findById(1L);
+        verify(memberQueryRepository, times(1))
+                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
 
-    // when & then
-    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-        999L, searchConditions, testUserDetails, pageable))
-        .isInstanceOf(RestException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-  }
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo(testUser.getNickname());
+    }
 
-  @Test
-  @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
-  void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
-    // given
-    User otherUser = User.builder()
-        .id(2L)
-        .email("other@example.com")
-        .nickname("otherUser")
-        .build();
+    @Test
+    @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
+    void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
+        // given
+        when(studyGroupRepository.findById(999L)).thenReturn(Optional.empty());
 
-    UserDetails otherUserDetails = UserDetails.builder()
-        .user(otherUser)
-        .build();
+        // when & then
+        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                999L, searchConditions, testUserDetails, pageable))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+    }
 
-    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+    @Test
+    @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
+    void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
+        // given
+        User otherUser = User.builder()
+                .id(2L)
+                .email("other@example.com")
+                .nickname("otherUser")
+                .build();
 
-    // when & then
-    assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-        1L, searchConditions, otherUserDetails, pageable))
-        .isInstanceOf(RestException.class)
-        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
-  }
+        UserDetails otherUserDetails = UserDetails.builder()
+                .user(otherUser)
+                .build();
 
-  @Test
-  @DisplayName("빈 검색 결과가 있을 때도 정상적으로 PagedModel을 반환한다")
-  void paginateStudyGroupMembers_WithEmptyResults_ShouldReturnEmptyPagedModel() {
-    // given
-    Page<MemberDto.MemberResponse> emptyPage = new PageImpl<>(
-        List.of(), pageable, 0L);
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
 
-    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-    when(memberQueryRepository.paginateStudyGroupMembers(
-        eq(testStudyGroup), eq(searchConditions), eq(pageable)))
-        .thenReturn(emptyPage);
+        // when & then
+        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                1L, searchConditions, otherUserDetails, pageable))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+    }
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        1L, searchConditions, testUserDetails, pageable);
+    @Test
+    @DisplayName("빈 검색 결과가 있을 때도 정상적으로 PagedModel을 반환한다")
+    void paginateStudyGroupMembers_WithEmptyResults_ShouldReturnEmptyPagedModel() {
+        // given
+        Page<MemberDto.MemberResponse> emptyPage = new PageImpl<>(
+                List.of(), pageable, 0L);
 
-    // then
-    verify(studyGroupRepository, times(1)).findById(1L);
-    verify(memberQueryRepository, times(1))
-        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+        when(memberQueryRepository.paginateStudyGroupMembers(
+                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+                .thenReturn(emptyPage);
 
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).isEmpty();
-  }
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                1L, searchConditions, testUserDetails, pageable);
 
-  @Test
-  @DisplayName("다양한 정렬 조건으로 멤버를 조회할 수 있다")
-  void paginateStudyGroupMembers_WithDifferentSortConditions_ShouldWorkCorrectly() {
-    // given
-    MemberDto.SearchConditions alphabetSortConditions = MemberDto.SearchConditions.builder()
-        .sort("alphabet")
-        .order("asc")
-        .build();
+        // then
+        verify(studyGroupRepository, times(1)).findById(1L);
+        verify(memberQueryRepository, times(1))
+                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
 
-    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-        List.of(testMemberResponse), pageable, 1L);
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+    }
 
-    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-    when(memberQueryRepository.paginateStudyGroupMembers(
-        eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable)))
-        .thenReturn(mockPage);
+    @Test
+    @DisplayName("다양한 정렬 조건으로 멤버를 조회할 수 있다")
+    void paginateStudyGroupMembers_WithDifferentSortConditions_ShouldWorkCorrectly() {
+        // given
+        MemberDto.SearchConditions alphabetSortConditions = MemberDto.SearchConditions.builder()
+                .sort("alphabet")
+                .order("asc")
+                .build();
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        1L, alphabetSortConditions, testUserDetails, pageable);
+        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                List.of(testMemberResponse), pageable, 1L);
 
-    // then
-    verify(studyGroupRepository, times(1)).findById(1L);
-    verify(memberQueryRepository, times(1))
-        .paginateStudyGroupMembers(eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable));
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+        when(memberQueryRepository.paginateStudyGroupMembers(
+                eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable)))
+                .thenReturn(mockPage);
 
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(1);
-  }
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                1L, alphabetSortConditions, testUserDetails, pageable);
 
-  @Test
-  @DisplayName("다양한 페이징 설정으로 멤버를 조회할 수 있다")
-  void paginateStudyGroupMembers_WithDifferentPageable_ShouldWorkCorrectly() {
-    // given
-    Pageable customPageable = PageRequest.of(1, 5); // 두 번째 페이지, 5개씩
+        // then
+        verify(studyGroupRepository, times(1)).findById(1L);
+        verify(memberQueryRepository, times(1))
+                .paginateStudyGroupMembers(eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable));
 
-    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-        List.of(testMemberResponse), customPageable, 1L);
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+    }
 
-    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-    when(memberQueryRepository.paginateStudyGroupMembers(
-        eq(testStudyGroup), eq(searchConditions), eq(customPageable)))
-        .thenReturn(mockPage);
+    @Test
+    @DisplayName("다양한 페이징 설정으로 멤버를 조회할 수 있다")
+    void paginateStudyGroupMembers_WithDifferentPageable_ShouldWorkCorrectly() {
+        // given
+        Pageable customPageable = PageRequest.of(1, 5); // 두 번째 페이지, 5개씩
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        1L, searchConditions, testUserDetails, customPageable);
+        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                List.of(testMemberResponse), customPageable, 1L);
 
-    // then
-    verify(studyGroupRepository, times(1)).findById(1L);
-    verify(memberQueryRepository, times(1))
-        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(customPageable));
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+        when(memberQueryRepository.paginateStudyGroupMembers(
+                eq(testStudyGroup), eq(searchConditions), eq(customPageable)))
+                .thenReturn(mockPage);
 
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(1);
-  }
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                1L, searchConditions, testUserDetails, customPageable);
 
-  @Test
-  @DisplayName("여러 명의 멤버가 있을 때 모든 결과를 반환한다")
-  void paginateStudyGroupMembers_WithMultipleResults_ShouldReturnAllResults() {
-    // given
-    User secondUser = User.builder()
-        .id(2L)
-        .email("second@example.com")
-        .nickname("secondUser")
-        .build();
+        // then
+        verify(studyGroupRepository, times(1)).findById(1L);
+        verify(memberQueryRepository, times(1))
+                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(customPageable));
 
-    MemberDto.MemberResponse secondMemberResponse = MemberDto.MemberResponse.builder()
-        .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
-            .id(secondUser.getId())
-            .email(secondUser.getEmail())
-            .nickname(secondUser.getNickname())
-            .build())
-        .createdAt(LocalDateTime.now())
-        .lastModifiedAt(LocalDateTime.now())
-        .build();
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+    }
 
-    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-        List.of(testMemberResponse, secondMemberResponse), pageable, 2L);
+    @Test
+    @DisplayName("여러 명의 멤버가 있을 때 모든 결과를 반환한다")
+    void paginateStudyGroupMembers_WithMultipleResults_ShouldReturnAllResults() {
+        // given
+        User secondUser = User.builder()
+                .id(2L)
+                .email("second@example.com")
+                .nickname("secondUser")
+                .build();
 
-    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-    when(memberQueryRepository.paginateStudyGroupMembers(
-        eq(testStudyGroup), eq(searchConditions), eq(pageable)))
-        .thenReturn(mockPage);
+        MemberDto.MemberResponse secondMemberResponse = MemberDto.MemberResponse.builder()
+                .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
+                        .id(secondUser.getId())
+                        .email(secondUser.getEmail())
+                        .nickname(secondUser.getNickname())
+                        .build())
+                .createdAt(LocalDateTime.now())
+                .lastModifiedAt(LocalDateTime.now())
+                .build();
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        1L, searchConditions, testUserDetails, pageable);
+        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                List.of(testMemberResponse, secondMemberResponse), pageable, 2L);
 
-    // then
-    verify(studyGroupRepository, times(1)).findById(1L);
-    verify(memberQueryRepository, times(1))
-        .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+        when(memberQueryRepository.paginateStudyGroupMembers(
+                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+                .thenReturn(mockPage);
 
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(2);
-    assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(1L);
-    assertThat(result.getContent().get(1).getUser().getId()).isEqualTo(2L);
-  }
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                1L, searchConditions, testUserDetails, pageable);
 
-  @Test
-  @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
-  void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
-    // given
-    MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
+        // then
+        verify(studyGroupRepository, times(1)).findById(1L);
+        verify(memberQueryRepository, times(1))
+                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
 
-    Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-        List.of(testMemberResponse), pageable, 1L);
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(1L);
+        assertThat(result.getContent().get(1).getUser().getId()).isEqualTo(2L);
+    }
 
-    when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-    when(memberQueryRepository.paginateStudyGroupMembers(
-        eq(testStudyGroup), eq(nullConditions), eq(pageable)))
-        .thenReturn(mockPage);
+    @Test
+    @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
+    void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
+        // given
+        MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
 
-    // when
-    PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-        1L, nullConditions, testUserDetails, pageable);
+        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                List.of(testMemberResponse), pageable, 1L);
 
-    // then
-    verify(studyGroupRepository, times(1)).findById(1L);
-    verify(memberQueryRepository, times(1))
-        .paginateStudyGroupMembers(eq(testStudyGroup), eq(nullConditions), eq(pageable));
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+        when(memberQueryRepository.paginateStudyGroupMembers(
+                eq(testStudyGroup), eq(nullConditions), eq(pageable)))
+                .thenReturn(mockPage);
 
-    assertThat(result).isNotNull();
-    assertThat(result.getContent()).hasSize(1);
-  }
+        // when
+        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                1L, nullConditions, testUserDetails, pageable);
+
+        // then
+        verify(studyGroupRepository, times(1)).findById(1L);
+        verify(memberQueryRepository, times(1))
+                .paginateStudyGroupMembers(eq(testStudyGroup), eq(nullConditions), eq(pageable));
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - 성공")
+    void expelMember_Success() {
+        // given
+        Long groupId = 1L;
+        Long userId = 2L;
+        UserDetails userDetails = mock(UserDetails.class);
+        User owner = mock(User.class);
+        User userToExpel = mock(User.class);
+        StudyGroup studyGroup = mock(StudyGroup.class);
+        Member member = mock(Member.class);
+
+        when(userDetails.getUser()).thenReturn(owner);
+        when(owner.getId()).thenReturn(1L);
+        when(userToExpel.getId()).thenReturn(2L);
+        when(studyGroup.getOwner()).thenReturn(owner);
+        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
+        when(memberRepository.findById_UserAndId_StudyGroup(userToExpel, studyGroup))
+                .thenReturn(Optional.of(member));
+
+        // when
+        memberService.expelMember(groupId, userId, userDetails);
+
+        // then
+        verify(memberRepository).delete(member);
+        verify(studyGroup).decreaseMemberCount();
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - owner가 아닌 경우 실패")
+    void expelMember_NotOwner_ThrowsException() {
+        // given
+        Long groupId = 1L;
+        Long userId = 2L;
+        UserDetails userDetails = mock(UserDetails.class);
+        User nonOwner = mock(User.class);
+        User userToExpel = mock(User.class);
+        StudyGroup studyGroup = mock(StudyGroup.class);
+        User owner = mock(User.class);
+
+        when(userDetails.getUser()).thenReturn(nonOwner);
+        when(nonOwner.getId()).thenReturn(3L);
+        when(owner.getId()).thenReturn(1L);
+        when(studyGroup.getOwner()).thenReturn(owner);
+        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - owner 자신을 추방하려는 경우 실패")
+    void expelMember_ExpelOwner_ThrowsException() {
+        // given
+        Long groupId = 1L;
+        Long userId = 1L; // owner의 ID
+        UserDetails userDetails = mock(UserDetails.class);
+        User owner = mock(User.class);
+        StudyGroup studyGroup = mock(StudyGroup.class);
+
+        when(userDetails.getUser()).thenReturn(owner);
+        when(owner.getId()).thenReturn(1L);
+        when(studyGroup.getOwner()).thenReturn(owner);
+        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(owner));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STUDY_GROUP_OWNER_CANNOT_BE_EXPELLED);
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - 스터디 그룹이 존재하지 않는 경우 실패")
+    void expelMember_StudyGroupNotFound_ThrowsException() {
+        // given
+        Long groupId = 999L;
+        Long userId = 2L;
+        UserDetails userDetails = mock(UserDetails.class);
+
+        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("스터디 그룹 멤버 추방 - 멤버가 존재하지 않는 경우 실패")
+    void expelMember_MemberNotFound_ThrowsException() {
+        // given
+        Long groupId = 1L;
+        Long userId = 2L;
+        UserDetails userDetails = mock(UserDetails.class);
+        User owner = mock(User.class);
+        User userToExpel = mock(User.class);
+        StudyGroup studyGroup = mock(StudyGroup.class);
+
+        when(userDetails.getUser()).thenReturn(owner);
+        when(owner.getId()).thenReturn(1L);
+        when(userToExpel.getId()).thenReturn(2L);
+        when(studyGroup.getOwner()).thenReturn(owner);
+        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
+        when(memberRepository.findById_UserAndId_StudyGroup(userToExpel, studyGroup))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                .isInstanceOf(RestException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+    }
 }


### PR DESCRIPTION
- MemberController에 멤버 추방 API 추가
- MemberService에 멤버 추방 로직 구현
- StudyGroup 엔티티에 멤버 수 감소 메서드 추가
- ErrorCode에 소유자 추방 불가 예외 추가
- 관련 테스트 케이스 작성 및 검증

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
