### PR TITLE
LNIT-38-스터디-그룹-탈퇴-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/MemberController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/MemberController.java
@@ -24,14 +24,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/study-groups/{groupId}/members")
+@RequestMapping("/api/study-groups/{groupId}")
 @Tag(name = "Study Group Member", description = "스터디 그룹 멤버 API")
 @RequiredArgsConstructor
 public class MemberController {
 
   private final MemberService memberService;
 
-  @GetMapping
+  @GetMapping("/members")
   @Operation(summary = "스터디 그룹 멤버 조회", description = "그룹의 owner 권한을 가진 사용자가 스터디 그룹의 멤버를 페이징하여 조회합니다.")
   public PagedModel<MemberDto.MemberResponse> getStudyGroupMembers(@PathVariable Long groupId,
       @ModelAttribute @ParameterObject MemberDto.SearchConditions searchConditions,
@@ -41,7 +41,7 @@ public class MemberController {
     return memberService.paginateStudyGroupMembers(groupId, searchConditions, userDetails, pageable);
   }
 
-  @DeleteMapping("/{userId}")
+  @DeleteMapping("/members/{userId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @Operation(summary = "스터디 그룹 멤버 추방", description = "그룹의 owner 권한을 가진 사용자가 스터디 그룹의 멤버를 추방합니다.")
   @ApiResponse(responseCode = "204", description = "멤버 추방 성공")
@@ -51,6 +51,17 @@ public class MemberController {
       @AuthenticationPrincipal UserDetails userDetails) {
 
     memberService.expelMember(groupId, userId, userDetails);
+  }
+
+  @DeleteMapping("/leave")
+  @Operation(summary = "스터디 그룹 탈퇴", description = "그룹에 가입된 유저(owner 제외)가 스터디 그룹에서 탈퇴합니다.")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiResponse(responseCode = "204", description = "그룹 탈퇴 성공")
+  @ApiResponse(responseCode = "403", description = "권한 없음")
+  @ApiResponse(responseCode = "404", description = "스터디 그룹을 찾을 수 없음")
+  public void leaveStudyGroup(@PathVariable Long groupId, @AuthenticationPrincipal UserDetails userDetails) {
+
+    memberService.leaveMember(groupId, userDetails);
   }
 
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyGroupController.java
@@ -6,7 +6,15 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.depth.learningcrew.domain.studygroup.dto.StudyGroupDto;
 import com.depth.learningcrew.domain.studygroup.service.StudyGroupService;
@@ -32,6 +40,7 @@ public class StudyGroupController {
       @ModelAttribute @ParameterObject StudyGroupDto.SearchConditions searchConditions,
       @PageableDefault @ParameterObject Pageable pageable,
       @AuthenticationPrincipal UserDetails userDetails) {
+
     return studyGroupService.paginateMyOwnedStudyGroups(searchConditions, userDetails, pageable);
   }
 
@@ -41,6 +50,7 @@ public class StudyGroupController {
       @PathVariable Long groupId,
       @Valid @ModelAttribute @ParameterObject StudyGroupDto.StudyGroupUpdateRequest request,
       @AuthenticationPrincipal UserDetails userDetails) {
+
     return studyGroupService.updateStudyGroup(groupId, request, userDetails);
   }
 
@@ -50,6 +60,7 @@ public class StudyGroupController {
   public StudyGroupDto.StudyGroupDetailResponse getStudyGroup(
       @PathVariable Long id,
       @AuthenticationPrincipal UserDetails userDetails) {
+
     return studyGroupService.getStudyGroupDetail(id, userDetails);
   }
 
@@ -58,8 +69,8 @@ public class StudyGroupController {
   public PagedModel<StudyGroupDto.StudyGroupResponse> getAllStudyGroups(
       @ModelAttribute @ParameterObject StudyGroupDto.SearchConditions searchConditions,
       @PageableDefault(page = 0, size = 10) @ParameterObject Pageable pageable,
-      @AuthenticationPrincipal UserDetails userDetails
-  ) {
+      @AuthenticationPrincipal UserDetails userDetails) {
+
     return studyGroupService.paginateAllStudyGroups(searchConditions, userDetails, pageable);
   }
 
@@ -69,15 +80,17 @@ public class StudyGroupController {
   public StudyGroupDto.StudyGroupDetailResponse createStudyGroup(
       @ModelAttribute StudyGroupDto.StudyGroupCreateRequest request,
       @AuthenticationPrincipal UserDetails userDetails) {
+
     return studyGroupService.createStudyGroup(request, userDetails);
   }
 
   @GetMapping("my/membered")
   @Operation(summary = "내가 가입한 스터디 그룹 목록 조회", description = "가입한 스터디 그룹 목록을 조건에 맞게 페이지네이션하여 조회합니다.")
   public PagedModel<StudyGroupDto.StudyGroupResponse> getMyMemberedStudyGroups(
-          @ModelAttribute @ParameterObject StudyGroupDto.SearchConditions searchConditions,
-          @PageableDefault(page = 0, size = 10) @ParameterObject Pageable pageable,
-          @AuthenticationPrincipal UserDetails userDetails) {
+      @ModelAttribute @ParameterObject StudyGroupDto.SearchConditions searchConditions,
+      @PageableDefault(page = 0, size = 10) @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal UserDetails userDetails) {
+
     return studyGroupService.paginateMyMemberedStudyGroups(searchConditions, userDetails, pageable);
   }
 
@@ -86,8 +99,9 @@ public class StudyGroupController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiResponse(responseCode = "204", description = "스터디 그룹 폐쇄 성공")
   public void deleteStudyGroup(
-          @PathVariable Long id,
-          @AuthenticationPrincipal UserDetails userDetails) {
+      @PathVariable Long id,
+      @AuthenticationPrincipal UserDetails userDetails) {
+
     studyGroupService.deleteStudyGroup(id, userDetails);
   }
 }

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceIntegrationTest.java
@@ -39,501 +39,646 @@ import jakarta.persistence.PersistenceContext;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class MemberServiceIntegrationTest {
 
-    @Autowired
-    private MemberService memberService;
+        @Autowired
+        private MemberService memberService;
 
-    @PersistenceContext
-    private EntityManager entityManager;
+        @PersistenceContext
+        private EntityManager entityManager;
 
-    private static volatile long testCounter = 0;
-    private long currentTestId;
+        private static volatile long testCounter = 0;
+        private long currentTestId;
 
-    private User owner;
-    private User member1;
-    private User member2;
-    private User otherUser;
-    private UserDetails ownerDetails;
-    private UserDetails otherUserDetails;
-    private StudyGroup studyGroup;
-    private Member memberEntity1;
-    private Member memberEntity2;
+        private User owner;
+        private User member1;
+        private User member2;
+        private User otherUser;
+        private UserDetails ownerDetails;
+        private UserDetails member1Details;
+        private UserDetails member2Details;
+        private UserDetails otherUserDetails;
+        private StudyGroup studyGroup;
+        private Member memberEntity1;
+        private Member memberEntity2;
 
-    @BeforeEach
-    void setUp() {
-        // 각 테스트마다 고유한 ID 생성
-        currentTestId = ++testCounter;
+        @BeforeEach
+        void setUp() {
+                // 각 테스트마다 고유한 ID 생성
+                currentTestId = ++testCounter;
 
-        // 기존 데이터 완전 정리 - 외래키 제약조건을 고려한 순서
-        entityManager.createQuery("DELETE FROM Member m").executeUpdate();
-        entityManager.createQuery("DELETE FROM Application a").executeUpdate();
-        entityManager.createQuery("DELETE FROM Dibs d").executeUpdate();
-        entityManager.createQuery("DELETE FROM StudyGroup s").executeUpdate();
-        entityManager.createQuery("DELETE FROM User u").executeUpdate();
-        entityManager.flush();
-        entityManager.clear(); // 영속성 컨텍스트 완전 초기화
+                // 기존 데이터 완전 정리 - 외래키 제약조건을 고려한 순서
+                entityManager.createQuery("DELETE FROM Member m").executeUpdate();
+                entityManager.createQuery("DELETE FROM Application a").executeUpdate();
+                entityManager.createQuery("DELETE FROM Dibs d").executeUpdate();
+                entityManager.createQuery("DELETE FROM StudyGroup s").executeUpdate();
+                entityManager.createQuery("DELETE FROM User u").executeUpdate();
+                entityManager.flush();
+                entityManager.clear(); // 영속성 컨텍스트 완전 초기화
 
-        // 테스트 사용자 생성 - 고유한 값 사용
-        String testId = String.valueOf(currentTestId);
+                // 테스트 사용자 생성 - 고유한 값 사용
+                String testId = String.valueOf(currentTestId);
 
-        owner = User.builder()
-                .email("owner_" + testId + "@test.com")
-                .password("password")
-                .nickname("owner_" + testId)
-                .birthday(LocalDate.of(1990, 1, 1))
-                .gender(Gender.MALE)
-                .role(Role.USER)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
+                owner = User.builder()
+                                .email("owner_" + testId + "@test.com")
+                                .password("password")
+                                .nickname("owner_" + testId)
+                                .birthday(LocalDate.of(1990, 1, 1))
+                                .gender(Gender.MALE)
+                                .role(Role.USER)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
 
-        member1 = User.builder()
-                .email("member1_" + testId + "@test.com")
-                .password("password")
-                .nickname("member1_" + testId)
-                .birthday(LocalDate.of(1991, 1, 1))
-                .gender(Gender.FEMALE)
-                .role(Role.USER)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
+                member1 = User.builder()
+                                .email("member1_" + testId + "@test.com")
+                                .password("password")
+                                .nickname("member1_" + testId)
+                                .birthday(LocalDate.of(1991, 1, 1))
+                                .gender(Gender.FEMALE)
+                                .role(Role.USER)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
 
-        member2 = User.builder()
-                .email("member2_" + testId + "@test.com")
-                .password("password")
-                .nickname("member2_" + testId)
-                .birthday(LocalDate.of(1992, 1, 1))
-                .gender(Gender.MALE)
-                .role(Role.USER)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
+                member2 = User.builder()
+                                .email("member2_" + testId + "@test.com")
+                                .password("password")
+                                .nickname("member2_" + testId)
+                                .birthday(LocalDate.of(1992, 1, 1))
+                                .gender(Gender.MALE)
+                                .role(Role.USER)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
 
-        otherUser = User.builder()
-                .email("other_" + testId + "@test.com")
-                .password("password")
-                .nickname("other_" + testId)
-                .birthday(LocalDate.of(1995, 1, 1))
-                .gender(Gender.FEMALE)
-                .role(Role.USER)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
+                otherUser = User.builder()
+                                .email("other_" + testId + "@test.com")
+                                .password("password")
+                                .nickname("other_" + testId)
+                                .birthday(LocalDate.of(1995, 1, 1))
+                                .gender(Gender.FEMALE)
+                                .role(Role.USER)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
 
-        // 스터디 그룹 생성
-        studyGroup = StudyGroup.builder()
-                .name("테스트 스터디 그룹_" + testId)
-                .summary("테스트 스터디 그룹입니다.")
-                .content("테스트 스터디 그룹 내용입니다.")
-                .maxMembers(10)
-                .memberCount(3)
-                .currentStep(1)
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusMonths(3))
-                .owner(owner)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
+                // 스터디 그룹 생성
+                studyGroup = StudyGroup.builder()
+                                .name("테스트 스터디 그룹_" + testId)
+                                .summary("테스트 스터디 그룹입니다.")
+                                .content("테스트 스터디 그룹 내용입니다.")
+                                .maxMembers(10)
+                                .memberCount(3)
+                                .currentStep(1)
+                                .startDate(LocalDate.now())
+                                .endDate(LocalDate.now().plusMonths(3))
+                                .owner(owner)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
 
-        // 엔티티들을 데이터베이스에 저장
-        entityManager.persist(owner);
-        entityManager.persist(member1);
-        entityManager.persist(member2);
-        entityManager.persist(otherUser);
-        entityManager.persist(studyGroup);
-        entityManager.flush();
+                // 엔티티들을 데이터베이스에 저장
+                entityManager.persist(owner);
+                entityManager.persist(member1);
+                entityManager.persist(member2);
+                entityManager.persist(otherUser);
+                entityManager.persist(studyGroup);
+                entityManager.flush();
 
-        // 멤버 엔티티 생성 및 저장
-        memberEntity1 = Member.builder()
-                .id(MemberId.of(member1, studyGroup))
-                .createdAt(LocalDateTime.now().minusDays(1))
-                .lastModifiedAt(LocalDateTime.now().minusDays(1))
-                .build();
+                // 멤버 엔티티 생성 및 저장
+                memberEntity1 = Member.builder()
+                                .id(MemberId.of(member1, studyGroup))
+                                .createdAt(LocalDateTime.now().minusDays(1))
+                                .lastModifiedAt(LocalDateTime.now().minusDays(1))
+                                .build();
 
-        memberEntity2 = Member.builder()
-                .id(MemberId.of(member2, studyGroup))
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
+                memberEntity2 = Member.builder()
+                                .id(MemberId.of(member2, studyGroup))
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
 
-        entityManager.persist(memberEntity1);
-        entityManager.persist(memberEntity2);
-        entityManager.flush();
+                entityManager.persist(memberEntity1);
+                entityManager.persist(memberEntity2);
+                entityManager.flush();
 
-        // UserDetails 생성
-        ownerDetails = UserDetails.builder()
-                .user(owner)
-                .build();
+                // UserDetails 생성
+                ownerDetails = UserDetails.builder()
+                                .user(owner)
+                                .build();
 
-        otherUserDetails = UserDetails.builder()
-                .user(otherUser)
-                .build();
-    }
+                member1Details = UserDetails.builder()
+                                .user(member1)
+                                .build();
 
-    @AfterEach
-    void tearDown() {
-        // 영속성 컨텍스트 초기화
-        if (entityManager != null) {
-            entityManager.clear();
+                member2Details = UserDetails.builder()
+                                .user(member2)
+                                .build();
+
+                otherUserDetails = UserDetails.builder()
+                                .user(otherUser)
+                                .build();
         }
-    }
 
-    @Test
-    @DisplayName("스터디 그룹 멤버를 성공적으로 페이징하여 조회할 수 있다")
-    void paginateStudyGroupMembers_ShouldReturnPagedResults() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+        @AfterEach
+        void tearDown() {
+                // 영속성 컨텍스트 초기화
+                if (entityManager != null) {
+                        entityManager.clear();
+                }
+        }
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        @Test
+        @DisplayName("스터디 그룹 멤버를 성공적으로 페이징하여 조회할 수 있다")
+        void paginateStudyGroupMembers_ShouldReturnPagedResults() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 최신 멤버
-        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 이전 멤버
-    }
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    @Test
-    @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
-    void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 최신
+                                                                                                                      // 멤버
+                assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 이전
+                                                                                                                      // 멤버
+        }
 
-        // when & then
-        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-                999L, searchConditions, ownerDetails, pageable))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-    }
+        @Test
+        @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
+        void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-    @Test
-    @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
-    void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+                // when & then
+                assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                                999L, searchConditions, ownerDetails, pageable))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
 
-        // when & then
-        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), searchConditions, otherUserDetails, pageable))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
-    }
+        @Test
+        @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
+        void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-    @Test
-    @DisplayName("알파벳 순으로 멤버를 정렬하여 조회할 수 있다")
-    void paginateStudyGroupMembers_WithAlphabetSort_ShouldReturnSortedResults() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("alphabet")
-                .order("asc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+                // when & then
+                assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), searchConditions, otherUserDetails, pageable))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+        }
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        @Test
+        @DisplayName("알파벳 순으로 멤버를 정렬하여 조회할 수 있다")
+        void paginateStudyGroupMembers_WithAlphabetSort_ShouldReturnSortedResults() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("alphabet")
+                                .order("asc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 알파벳 순
-        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member2_" + currentTestId);
-    }
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    @Test
-    @DisplayName("알파벳 역순으로 멤버를 정렬하여 조회할 수 있다")
-    void paginateStudyGroupMembers_WithAlphabetDescSort_ShouldReturnSortedResults() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("alphabet")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 알파벳
+                                                                                                                      // 순
+                assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member2_" + currentTestId);
+        }
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        @Test
+        @DisplayName("알파벳 역순으로 멤버를 정렬하여 조회할 수 있다")
+        void paginateStudyGroupMembers_WithAlphabetDescSort_ShouldReturnSortedResults() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("alphabet")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 알파벳 역순
-        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId);
-    }
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    @Test
-    @DisplayName("페이징을 통해 멤버를 조회할 수 있다")
-    void paginateStudyGroupMembers_WithPaging_ShouldReturnPagedResults() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 1); // 첫 번째 페이지, 1개씩
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 알파벳
+                                                                                                                      // 역순
+                assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId);
+        }
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        @Test
+        @DisplayName("페이징을 통해 멤버를 조회할 수 있다")
+        void paginateStudyGroupMembers_WithPaging_ShouldReturnPagedResults() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 1); // 첫 번째 페이지, 1개씩
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 최신 멤버
-    }
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    @Test
-    @DisplayName("두 번째 페이지를 조회할 수 있다")
-    void paginateStudyGroupMembers_WithSecondPage_ShouldReturnSecondPageResults() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(1, 1); // 두 번째 페이지, 1개씩
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId); // 최신
+                                                                                                                      // 멤버
+        }
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        @Test
+        @DisplayName("두 번째 페이지를 조회할 수 있다")
+        void paginateStudyGroupMembers_WithSecondPage_ShouldReturnSecondPageResults() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(1, 1); // 두 번째 페이지, 1개씩
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 이전 멤버
-    }
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    @Test
-    @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
-    void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
-        // given
-        MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
-        Pageable pageable = PageRequest.of(0, 10);
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member1_" + currentTestId); // 이전
+                                                                                                                      // 멤버
+        }
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), nullConditions, ownerDetails, pageable);
+        @Test
+        @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
+        void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
+                // given
+                MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
+                Pageable pageable = PageRequest.of(0, 10);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(2);
-        // 기본값은 created_at desc이므로 최신 멤버가 먼저 나와야 함
-        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId);
-        assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId);
-    }
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), nullConditions, ownerDetails, pageable);
 
-    @Test
-    @DisplayName("멤버가 없는 스터디 그룹도 정상적으로 처리된다")
-    void paginateStudyGroupMembers_WithNoMembers_ShouldReturnEmptyResults() {
-        // given
-        // 멤버가 없는 새로운 스터디 그룹 생성
-        StudyGroup emptyStudyGroup = StudyGroup.builder()
-                .name("빈 스터디 그룹_" + currentTestId)
-                .summary("멤버가 없는 스터디 그룹")
-                .maxMembers(10)
-                .memberCount(0)
-                .currentStep(1)
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusMonths(3))
-                .owner(owner)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(2);
+                // 기본값은 created_at desc이므로 최신 멤버가 먼저 나와야 함
+                assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo("member2_" + currentTestId);
+                assertThat(result.getContent().get(1).getUser().getNickname()).isEqualTo("member1_" + currentTestId);
+        }
 
-        entityManager.persist(emptyStudyGroup);
-        entityManager.flush();
+        @Test
+        @DisplayName("멤버가 없는 스터디 그룹도 정상적으로 처리된다")
+        void paginateStudyGroupMembers_WithNoMembers_ShouldReturnEmptyResults() {
+                // given
+                // 멤버가 없는 새로운 스터디 그룹 생성
+                StudyGroup emptyStudyGroup = StudyGroup.builder()
+                                .name("빈 스터디 그룹_" + currentTestId)
+                                .summary("멤버가 없는 스터디 그룹")
+                                .maxMembers(10)
+                                .memberCount(0)
+                                .currentStep(1)
+                                .startDate(LocalDate.now())
+                                .endDate(LocalDate.now().plusMonths(3))
+                                .owner(owner)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
 
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+                entityManager.persist(emptyStudyGroup);
+                entityManager.flush();
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                emptyStudyGroup.getId(), searchConditions, ownerDetails, pageable);
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).isEmpty();
-    }
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                emptyStudyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-    @Test
-    @DisplayName("멤버 정보에 사용자 정보가 포함되어 있다")
-    void paginateStudyGroupMembers_ShouldIncludeUserInformation() {
-        // given
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).isEmpty();
+        }
 
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                studyGroup.getId(), searchConditions, ownerDetails, pageable);
+        @Test
+        @DisplayName("멤버 정보에 사용자 정보가 포함되어 있다")
+        void paginateStudyGroupMembers_ShouldIncludeUserInformation() {
+                // given
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(2);
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                studyGroup.getId(), searchConditions, ownerDetails, pageable);
 
-        MemberDto.MemberResponse firstMember = result.getContent().get(0);
-        assertThat(firstMember.getUser()).isNotNull();
-        assertThat(firstMember.getUser().getId()).isEqualTo(member2.getId());
-        assertThat(firstMember.getUser().getEmail()).isEqualTo("member2_" + currentTestId + "@test.com");
-        assertThat(firstMember.getUser().getNickname()).isEqualTo("member2_" + currentTestId);
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(2);
 
-        assertThat(firstMember.getCreatedAt()).isNotNull();
-        assertThat(firstMember.getLastModifiedAt()).isNotNull();
-    }
+                MemberDto.MemberResponse firstMember = result.getContent().get(0);
+                assertThat(firstMember.getUser()).isNotNull();
+                assertThat(firstMember.getUser().getId()).isEqualTo(member2.getId());
+                assertThat(firstMember.getUser().getEmail()).isEqualTo("member2_" + currentTestId + "@test.com");
+                assertThat(firstMember.getUser().getNickname()).isEqualTo("member2_" + currentTestId);
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - 성공")
-    void expelMember_Success() {
-        // given
-        Long groupId = studyGroup.getId();
-        Long userId = member1.getId();
+                assertThat(firstMember.getCreatedAt()).isNotNull();
+                assertThat(firstMember.getLastModifiedAt()).isNotNull();
+        }
 
-        // when
-        memberService.expelMember(groupId, userId, ownerDetails);
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - 성공")
+        void expelMember_Success() {
+                // given
+                Long groupId = studyGroup.getId();
+                Long userId = member1.getId();
 
-        // then
-        // 멤버가 실제로 삭제되었는지 확인
-        Member deletedMember = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
-        assertThat(deletedMember).isNull();
+                // when
+                memberService.expelMember(groupId, userId, ownerDetails);
 
-        // 스터디 그룹의 멤버 수가 감소했는지 확인
-        StudyGroup updatedStudyGroup = entityManager.find(StudyGroup.class, groupId);
-        assertThat(updatedStudyGroup.getMemberCount()).isEqualTo(2); // 3 -> 2
-    }
+                // then
+                // 멤버가 실제로 삭제되었는지 확인
+                Member deletedMember = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+                assertThat(deletedMember).isNull();
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - owner가 아닌 경우 실패")
-    void expelMember_NotOwner_ThrowsException() {
-        // given
-        Long groupId = studyGroup.getId();
-        Long userId = member1.getId();
+                // 스터디 그룹의 멤버 수가 감소했는지 확인
+                StudyGroup updatedStudyGroup = entityManager.find(StudyGroup.class, groupId);
+                assertThat(updatedStudyGroup.getMemberCount()).isEqualTo(2); // 3 -> 2
+        }
 
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, otherUserDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - owner가 아닌 경우 실패")
+        void expelMember_NotOwner_ThrowsException() {
+                // given
+                Long groupId = studyGroup.getId();
+                Long userId = member1.getId();
 
-        // 멤버가 삭제되지 않았는지 확인
-        Member member = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
-        assertThat(member).isNotNull();
-    }
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, otherUserDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - owner 자신을 추방하려는 경우 실패")
-    void expelMember_ExpelOwner_ThrowsException() {
-        // given
-        Long groupId = studyGroup.getId();
-        Long userId = owner.getId();
+                // 멤버가 삭제되지 않았는지 확인
+                Member member = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+                assertThat(member).isNotNull();
+        }
 
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STUDY_GROUP_OWNER_CANNOT_BE_EXPELLED);
-    }
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - owner 자신을 추방하려는 경우 실패")
+        void expelMember_ExpelOwner_ThrowsException() {
+                // given
+                Long groupId = studyGroup.getId();
+                Long userId = owner.getId();
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - 존재하지 않는 스터디 그룹 실패")
-    void expelMember_NonExistentStudyGroup_ThrowsException() {
-        // given
-        Long groupId = 999L;
-        Long userId = member1.getId();
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode",
+                                                ErrorCode.STUDY_GROUP_OWNER_CANNOT_BE_EXPELLED);
+        }
 
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-    }
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - 존재하지 않는 스터디 그룹 실패")
+        void expelMember_NonExistentStudyGroup_ThrowsException() {
+                // given
+                Long groupId = 999L;
+                Long userId = member1.getId();
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - 존재하지 않는 사용자 실패")
-    void expelMember_NonExistentUser_ThrowsException() {
-        // given
-        Long groupId = studyGroup.getId();
-        Long userId = 999L;
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
 
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-    }
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - 존재하지 않는 사용자 실패")
+        void expelMember_NonExistentUser_ThrowsException() {
+                // given
+                Long groupId = studyGroup.getId();
+                Long userId = 999L;
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - 그룹에 속하지 않은 사용자 실패")
-    void expelMember_UserNotInGroup_ThrowsException() {
-        // given
-        Long groupId = studyGroup.getId();
-        Long userId = otherUser.getId();
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
 
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-    }
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - 그룹에 속하지 않은 사용자 실패")
+        void expelMember_UserNotInGroup_ThrowsException() {
+                // given
+                Long groupId = studyGroup.getId();
+                Long userId = otherUser.getId();
 
-    @Test
-    @DisplayName("여러 멤버를 순차적으로 추방할 수 있다")
-    void expelMultipleMembers_Success() {
-        // given
-        Long groupId = studyGroup.getId();
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, ownerDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
 
-        // when - 첫 번째 멤버 추방
-        memberService.expelMember(groupId, member1.getId(), ownerDetails);
+        @Test
+        @DisplayName("여러 멤버를 순차적으로 추방할 수 있다")
+        void expelMultipleMembers_Success() {
+                // given
+                Long groupId = studyGroup.getId();
 
-        // then - 첫 번째 멤버 추방 확인
-        Member deletedMember1 = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
-        assertThat(deletedMember1).isNull();
+                // when - 첫 번째 멤버 추방
+                memberService.expelMember(groupId, member1.getId(), ownerDetails);
 
-        StudyGroup studyGroupAfterFirstExpel = entityManager.find(StudyGroup.class, groupId);
-        assertThat(studyGroupAfterFirstExpel.getMemberCount()).isEqualTo(2);
+                // then - 첫 번째 멤버 추방 확인
+                Member deletedMember1 = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+                assertThat(deletedMember1).isNull();
 
-        // when - 두 번째 멤버 추방
-        memberService.expelMember(groupId, member2.getId(), ownerDetails);
+                StudyGroup studyGroupAfterFirstExpel = entityManager.find(StudyGroup.class, groupId);
+                assertThat(studyGroupAfterFirstExpel.getMemberCount()).isEqualTo(2);
 
-        // then - 두 번째 멤버 추방 확인
-        Member deletedMember2 = entityManager.find(Member.class, MemberId.of(member2, studyGroup));
-        assertThat(deletedMember2).isNull();
+                // when - 두 번째 멤버 추방
+                memberService.expelMember(groupId, member2.getId(), ownerDetails);
 
-        StudyGroup studyGroupAfterSecondExpel = entityManager.find(StudyGroup.class, groupId);
-        assertThat(studyGroupAfterSecondExpel.getMemberCount()).isEqualTo(1);
-    }
+                // then - 두 번째 멤버 추방 확인
+                Member deletedMember2 = entityManager.find(Member.class, MemberId.of(member2, studyGroup));
+                assertThat(deletedMember2).isNull();
 
-    @Test
-    @DisplayName("멤버 추방 후 멤버 조회에서 제외된다")
-    void expelMember_ShouldBeExcludedFromMemberList() {
-        // given
-        Long groupId = studyGroup.getId();
-        Long userId = member1.getId();
+                StudyGroup studyGroupAfterSecondExpel = entityManager.find(StudyGroup.class, groupId);
+                assertThat(studyGroupAfterSecondExpel.getMemberCount()).isEqualTo(1);
+        }
 
-        // when - 멤버 추방
-        memberService.expelMember(groupId, userId, ownerDetails);
+        @Test
+        @DisplayName("멤버 추방 후 멤버 조회에서 제외된다")
+        void expelMember_ShouldBeExcludedFromMemberList() {
+                // given
+                Long groupId = studyGroup.getId();
+                Long userId = member1.getId();
 
-        // then - 멤버 조회에서 제외되었는지 확인
-        MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+                // when - 멤버 추방
+                memberService.expelMember(groupId, userId, ownerDetails);
 
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                groupId, searchConditions, ownerDetails, pageable);
+                // then - 멤버 조회에서 제외되었는지 확인
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
 
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(member2.getId());
-    }
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                groupId, searchConditions, ownerDetails, pageable);
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(member2.getId());
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - 성공")
+        void leaveMember_Success() {
+                // given
+                Long groupId = studyGroup.getId();
+
+                // when
+                memberService.leaveMember(groupId, member1Details);
+
+                // then
+                // 멤버가 실제로 삭제되었는지 확인
+                Member deletedMember = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+                assertThat(deletedMember).isNull();
+
+                // 스터디 그룹의 멤버 수가 감소했는지 확인
+                StudyGroup updatedStudyGroup = entityManager.find(StudyGroup.class, groupId);
+                assertThat(updatedStudyGroup.getMemberCount()).isEqualTo(2); // 3 -> 2
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - owner가 탈퇴하려는 경우 실패")
+        void leaveMember_OwnerCannotLeave_ThrowsException() {
+                // given
+                Long groupId = studyGroup.getId();
+
+                // when & then
+                assertThatThrownBy(() -> memberService.leaveMember(groupId, ownerDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+
+                // 스터디 그룹의 멤버 수가 변경되지 않았는지 확인
+                StudyGroup unchangedStudyGroup = entityManager.find(StudyGroup.class, groupId);
+                assertThat(unchangedStudyGroup.getMemberCount()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - 그룹에 속하지 않은 유저가 탈퇴하려는 경우 실패")
+        void leaveMember_UserNotInGroup_ThrowsException() {
+                // given
+                Long groupId = studyGroup.getId();
+
+                // when & then
+                assertThatThrownBy(() -> memberService.leaveMember(groupId, otherUserDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+
+                // 스터디 그룹의 멤버 수가 변경되지 않았는지 확인
+                StudyGroup unchangedStudyGroup = entityManager.find(StudyGroup.class, groupId);
+                assertThat(unchangedStudyGroup.getMemberCount()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - 존재하지 않는 스터디 그룹인 경우 실패")
+        void leaveMember_NonExistentStudyGroup_ThrowsException() {
+                // given
+                Long groupId = 999L;
+
+                // when & then
+                assertThatThrownBy(() -> memberService.leaveMember(groupId, member1Details))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("멤버 탈퇴 후 멤버 조회에서 제외된다")
+        void leaveMember_ShouldBeExcludedFromMemberList() {
+                // given
+                Long groupId = studyGroup.getId();
+
+                // when - 멤버 탈퇴
+                memberService.leaveMember(groupId, member1Details);
+
+                // then - 멤버 조회에서 제외되었는지 확인
+                MemberDto.SearchConditions searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+                Pageable pageable = PageRequest.of(0, 10);
+
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                groupId, searchConditions, ownerDetails, pageable);
+
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(member2.getId());
+        }
+
+        @Test
+        @DisplayName("여러 멤버가 순차적으로 탈퇴할 수 있다")
+        void leaveMultipleMembers_Success() {
+                // given
+                Long groupId = studyGroup.getId();
+
+                // when - 첫 번째 멤버 탈퇴
+                memberService.leaveMember(groupId, member1Details);
+
+                // then - 첫 번째 멤버 탈퇴 확인
+                Member deletedMember1 = entityManager.find(Member.class, MemberId.of(member1, studyGroup));
+                assertThat(deletedMember1).isNull();
+
+                StudyGroup studyGroupAfterFirstLeave = entityManager.find(StudyGroup.class, groupId);
+                assertThat(studyGroupAfterFirstLeave.getMemberCount()).isEqualTo(2);
+
+                // when - 두 번째 멤버 탈퇴
+                memberService.leaveMember(groupId, member2Details);
+
+                // then - 두 번째 멤버 탈퇴 확인
+                Member deletedMember2 = entityManager.find(Member.class, MemberId.of(member2, studyGroup));
+                assertThat(deletedMember2).isNull();
+
+                StudyGroup studyGroupAfterSecondLeave = entityManager.find(StudyGroup.class, groupId);
+                assertThat(studyGroupAfterSecondLeave.getMemberCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("탈퇴한 멤버가 다시 탈퇴를 시도하면 실패한다")
+        void leaveMember_AlreadyLeftMember_ThrowsException() {
+                // given
+                Long groupId = studyGroup.getId();
+
+                // 먼저 멤버 탈퇴
+                memberService.leaveMember(groupId, member1Details);
+
+                // when & then - 이미 탈퇴한 멤버가 다시 탈퇴 시도
+                assertThatThrownBy(() -> memberService.leaveMember(groupId, member1Details))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+        }
 }

--- a/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/studygroup/service/MemberServiceTest.java
@@ -43,411 +43,500 @@ import com.depth.learningcrew.system.security.model.UserDetails;
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @Mock
-    private MemberQueryRepository memberQueryRepository;
-
-    @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
-    private StudyGroupRepository studyGroupRepository;
-
-    @Mock
-    private UserRepository userRepository;
-
-    @InjectMocks
-    private MemberService memberService;
-
-    private User testUser;
-    private UserDetails testUserDetails;
-    private StudyGroup testStudyGroup;
-    private MemberDto.SearchConditions searchConditions;
-    private Pageable pageable;
-    private MemberDto.MemberResponse testMemberResponse;
-
-    @BeforeEach
-    void setUp() {
-        // 테스트 사용자 설정
-        testUser = User.builder()
-                .id(1L)
-                .email("test@example.com")
-                .password("password")
-                .nickname("testUser")
-                .birthday(LocalDate.of(1990, 1, 1))
-                .gender(Gender.MALE)
-                .role(Role.USER)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
-
-        testUserDetails = UserDetails.builder()
-                .user(testUser)
-                .build();
-
-        // 테스트 스터디 그룹 설정
-        testStudyGroup = StudyGroup.builder()
-                .id(1L)
-                .name("테스트 스터디 그룹")
-                .summary("테스트 스터디 그룹입니다.")
-                .maxMembers(10)
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusMonths(3))
-                .owner(testUser)
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
-
-        // 테스트 멤버 응답 DTO 설정
-        testMemberResponse = MemberDto.MemberResponse.builder()
-                .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
-                        .id(testUser.getId())
-                        .email(testUser.getEmail())
-                        .nickname(testUser.getNickname())
-                        .build())
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
-
-        // 검색 조건 설정
-        searchConditions = MemberDto.SearchConditions.builder()
-                .sort("created_at")
-                .order("desc")
-                .build();
-
-        // 페이징 설정
-        pageable = PageRequest.of(0, 10);
-    }
-
-    @Test
-    @DisplayName("스터디 그룹 멤버를 페이징하여 조회할 수 있다")
-    void paginateStudyGroupMembers_ShouldReturnPagedResults() {
-        // given
-        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-                List.of(testMemberResponse), pageable, 1L);
-
-        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-        when(memberQueryRepository.paginateStudyGroupMembers(
-                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
-                .thenReturn(mockPage);
-
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                1L, searchConditions, testUserDetails, pageable);
-
-        // then
-        verify(studyGroupRepository, times(1)).findById(1L);
-        verify(memberQueryRepository, times(1))
-                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
-
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(testUser.getId());
-        assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo(testUser.getNickname());
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
-    void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
-        // given
-        when(studyGroupRepository.findById(999L)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-                999L, searchConditions, testUserDetails, pageable))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
-    void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
-        // given
-        User otherUser = User.builder()
-                .id(2L)
-                .email("other@example.com")
-                .nickname("otherUser")
-                .build();
-
-        UserDetails otherUserDetails = UserDetails.builder()
-                .user(otherUser)
-                .build();
-
-        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-
-        // when & then
-        assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
-                1L, searchConditions, otherUserDetails, pageable))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
-    }
-
-    @Test
-    @DisplayName("빈 검색 결과가 있을 때도 정상적으로 PagedModel을 반환한다")
-    void paginateStudyGroupMembers_WithEmptyResults_ShouldReturnEmptyPagedModel() {
-        // given
-        Page<MemberDto.MemberResponse> emptyPage = new PageImpl<>(
-                List.of(), pageable, 0L);
-
-        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-        when(memberQueryRepository.paginateStudyGroupMembers(
-                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
-                .thenReturn(emptyPage);
-
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                1L, searchConditions, testUserDetails, pageable);
-
-        // then
-        verify(studyGroupRepository, times(1)).findById(1L);
-        verify(memberQueryRepository, times(1))
-                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
-
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("다양한 정렬 조건으로 멤버를 조회할 수 있다")
-    void paginateStudyGroupMembers_WithDifferentSortConditions_ShouldWorkCorrectly() {
-        // given
-        MemberDto.SearchConditions alphabetSortConditions = MemberDto.SearchConditions.builder()
-                .sort("alphabet")
-                .order("asc")
-                .build();
-
-        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-                List.of(testMemberResponse), pageable, 1L);
-
-        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-        when(memberQueryRepository.paginateStudyGroupMembers(
-                eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable)))
-                .thenReturn(mockPage);
-
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                1L, alphabetSortConditions, testUserDetails, pageable);
-
-        // then
-        verify(studyGroupRepository, times(1)).findById(1L);
-        verify(memberQueryRepository, times(1))
-                .paginateStudyGroupMembers(eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable));
-
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("다양한 페이징 설정으로 멤버를 조회할 수 있다")
-    void paginateStudyGroupMembers_WithDifferentPageable_ShouldWorkCorrectly() {
-        // given
-        Pageable customPageable = PageRequest.of(1, 5); // 두 번째 페이지, 5개씩
-
-        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-                List.of(testMemberResponse), customPageable, 1L);
-
-        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-        when(memberQueryRepository.paginateStudyGroupMembers(
-                eq(testStudyGroup), eq(searchConditions), eq(customPageable)))
-                .thenReturn(mockPage);
-
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                1L, searchConditions, testUserDetails, customPageable);
-
-        // then
-        verify(studyGroupRepository, times(1)).findById(1L);
-        verify(memberQueryRepository, times(1))
-                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(customPageable));
-
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("여러 명의 멤버가 있을 때 모든 결과를 반환한다")
-    void paginateStudyGroupMembers_WithMultipleResults_ShouldReturnAllResults() {
-        // given
-        User secondUser = User.builder()
-                .id(2L)
-                .email("second@example.com")
-                .nickname("secondUser")
-                .build();
-
-        MemberDto.MemberResponse secondMemberResponse = MemberDto.MemberResponse.builder()
-                .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
-                        .id(secondUser.getId())
-                        .email(secondUser.getEmail())
-                        .nickname(secondUser.getNickname())
-                        .build())
-                .createdAt(LocalDateTime.now())
-                .lastModifiedAt(LocalDateTime.now())
-                .build();
-
-        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-                List.of(testMemberResponse, secondMemberResponse), pageable, 2L);
-
-        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-        when(memberQueryRepository.paginateStudyGroupMembers(
-                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
-                .thenReturn(mockPage);
-
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                1L, searchConditions, testUserDetails, pageable);
-
-        // then
-        verify(studyGroupRepository, times(1)).findById(1L);
-        verify(memberQueryRepository, times(1))
-                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
-
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(1L);
-        assertThat(result.getContent().get(1).getUser().getId()).isEqualTo(2L);
-    }
-
-    @Test
-    @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
-    void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
-        // given
-        MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
-
-        Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
-                List.of(testMemberResponse), pageable, 1L);
-
-        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
-        when(memberQueryRepository.paginateStudyGroupMembers(
-                eq(testStudyGroup), eq(nullConditions), eq(pageable)))
-                .thenReturn(mockPage);
-
-        // when
-        PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
-                1L, nullConditions, testUserDetails, pageable);
-
-        // then
-        verify(studyGroupRepository, times(1)).findById(1L);
-        verify(memberQueryRepository, times(1))
-                .paginateStudyGroupMembers(eq(testStudyGroup), eq(nullConditions), eq(pageable));
-
-        assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - 성공")
-    void expelMember_Success() {
-        // given
-        Long groupId = 1L;
-        Long userId = 2L;
-        UserDetails userDetails = mock(UserDetails.class);
-        User owner = mock(User.class);
-        User userToExpel = mock(User.class);
-        StudyGroup studyGroup = mock(StudyGroup.class);
-        Member member = mock(Member.class);
-
-        when(userDetails.getUser()).thenReturn(owner);
-        when(owner.getId()).thenReturn(1L);
-        when(userToExpel.getId()).thenReturn(2L);
-        when(studyGroup.getOwner()).thenReturn(owner);
-        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
-        when(memberRepository.findById_UserAndId_StudyGroup(userToExpel, studyGroup))
-                .thenReturn(Optional.of(member));
-
-        // when
-        memberService.expelMember(groupId, userId, userDetails);
-
-        // then
-        verify(memberRepository).delete(member);
-        verify(studyGroup).decreaseMemberCount();
-    }
-
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - owner가 아닌 경우 실패")
-    void expelMember_NotOwner_ThrowsException() {
-        // given
-        Long groupId = 1L;
-        Long userId = 2L;
-        UserDetails userDetails = mock(UserDetails.class);
-        User nonOwner = mock(User.class);
-        User userToExpel = mock(User.class);
-        StudyGroup studyGroup = mock(StudyGroup.class);
-        User owner = mock(User.class);
-
-        when(userDetails.getUser()).thenReturn(nonOwner);
-        when(nonOwner.getId()).thenReturn(3L);
-        when(owner.getId()).thenReturn(1L);
-        when(studyGroup.getOwner()).thenReturn(owner);
-        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
-
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
-    }
-
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - owner 자신을 추방하려는 경우 실패")
-    void expelMember_ExpelOwner_ThrowsException() {
-        // given
-        Long groupId = 1L;
-        Long userId = 1L; // owner의 ID
-        UserDetails userDetails = mock(UserDetails.class);
-        User owner = mock(User.class);
-        StudyGroup studyGroup = mock(StudyGroup.class);
-
-        when(userDetails.getUser()).thenReturn(owner);
-        when(owner.getId()).thenReturn(1L);
-        when(studyGroup.getOwner()).thenReturn(owner);
-        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
-        when(userRepository.findById(userId)).thenReturn(Optional.of(owner));
-
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STUDY_GROUP_OWNER_CANNOT_BE_EXPELLED);
-    }
-
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - 스터디 그룹이 존재하지 않는 경우 실패")
-    void expelMember_StudyGroupNotFound_ThrowsException() {
-        // given
-        Long groupId = 999L;
-        Long userId = 2L;
-        UserDetails userDetails = mock(UserDetails.class);
-
-        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("스터디 그룹 멤버 추방 - 멤버가 존재하지 않는 경우 실패")
-    void expelMember_MemberNotFound_ThrowsException() {
-        // given
-        Long groupId = 1L;
-        Long userId = 2L;
-        UserDetails userDetails = mock(UserDetails.class);
-        User owner = mock(User.class);
-        User userToExpel = mock(User.class);
-        StudyGroup studyGroup = mock(StudyGroup.class);
-
-        when(userDetails.getUser()).thenReturn(owner);
-        when(owner.getId()).thenReturn(1L);
-        when(userToExpel.getId()).thenReturn(2L);
-        when(studyGroup.getOwner()).thenReturn(owner);
-        when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
-        when(memberRepository.findById_UserAndId_StudyGroup(userToExpel, studyGroup))
-                .thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
-                .isInstanceOf(RestException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
-    }
+        @Mock
+        private MemberQueryRepository memberQueryRepository;
+
+        @Mock
+        private MemberRepository memberRepository;
+
+        @Mock
+        private StudyGroupRepository studyGroupRepository;
+
+        @Mock
+        private UserRepository userRepository;
+
+        @InjectMocks
+        private MemberService memberService;
+
+        private User testUser;
+        private UserDetails testUserDetails;
+        private StudyGroup testStudyGroup;
+        private MemberDto.SearchConditions searchConditions;
+        private Pageable pageable;
+        private MemberDto.MemberResponse testMemberResponse;
+
+        @BeforeEach
+        void setUp() {
+                // 테스트 사용자 설정
+                testUser = User.builder()
+                                .id(1L)
+                                .email("test@example.com")
+                                .password("password")
+                                .nickname("testUser")
+                                .birthday(LocalDate.of(1990, 1, 1))
+                                .gender(Gender.MALE)
+                                .role(Role.USER)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
+
+                testUserDetails = UserDetails.builder()
+                                .user(testUser)
+                                .build();
+
+                // 테스트 스터디 그룹 설정
+                testStudyGroup = StudyGroup.builder()
+                                .id(1L)
+                                .name("테스트 스터디 그룹")
+                                .summary("테스트 스터디 그룹입니다.")
+                                .maxMembers(10)
+                                .startDate(LocalDate.now())
+                                .endDate(LocalDate.now().plusMonths(3))
+                                .owner(testUser)
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
+
+                // 테스트 멤버 응답 DTO 설정
+                testMemberResponse = MemberDto.MemberResponse.builder()
+                                .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
+                                                .id(testUser.getId())
+                                                .email(testUser.getEmail())
+                                                .nickname(testUser.getNickname())
+                                                .build())
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
+
+                // 검색 조건 설정
+                searchConditions = MemberDto.SearchConditions.builder()
+                                .sort("created_at")
+                                .order("desc")
+                                .build();
+
+                // 페이징 설정
+                pageable = PageRequest.of(0, 10);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 멤버를 페이징하여 조회할 수 있다")
+        void paginateStudyGroupMembers_ShouldReturnPagedResults() {
+                // given
+                Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                                List.of(testMemberResponse), pageable, 1L);
+
+                when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+                when(memberQueryRepository.paginateStudyGroupMembers(
+                                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+                                .thenReturn(mockPage);
+
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                1L, searchConditions, testUserDetails, pageable);
+
+                // then
+                verify(studyGroupRepository, times(1)).findById(1L);
+                verify(memberQueryRepository, times(1))
+                                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(1);
+                assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(testUser.getId());
+                assertThat(result.getContent().get(0).getUser().getNickname()).isEqualTo(testUser.getNickname());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 스터디 그룹을 조회하려고 하면 예외가 발생한다")
+        void paginateStudyGroupMembers_WithNonExistentGroup_ShouldThrowException() {
+                // given
+                when(studyGroupRepository.findById(999L)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                                999L, searchConditions, testUserDetails, pageable))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("owner가 아닌 사용자가 멤버를 조회하려고 하면 예외가 발생한다")
+        void paginateStudyGroupMembers_WithNonOwner_ShouldThrowException() {
+                // given
+                User otherUser = User.builder()
+                                .id(2L)
+                                .email("other@example.com")
+                                .nickname("otherUser")
+                                .build();
+
+                UserDetails otherUserDetails = UserDetails.builder()
+                                .user(otherUser)
+                                .build();
+
+                when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+
+                // when & then
+                assertThatThrownBy(() -> memberService.paginateStudyGroupMembers(
+                                1L, searchConditions, otherUserDetails, pageable))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("빈 검색 결과가 있을 때도 정상적으로 PagedModel을 반환한다")
+        void paginateStudyGroupMembers_WithEmptyResults_ShouldReturnEmptyPagedModel() {
+                // given
+                Page<MemberDto.MemberResponse> emptyPage = new PageImpl<>(
+                                List.of(), pageable, 0L);
+
+                when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+                when(memberQueryRepository.paginateStudyGroupMembers(
+                                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+                                .thenReturn(emptyPage);
+
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                1L, searchConditions, testUserDetails, pageable);
+
+                // then
+                verify(studyGroupRepository, times(1)).findById(1L);
+                verify(memberQueryRepository, times(1))
+                                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다양한 정렬 조건으로 멤버를 조회할 수 있다")
+        void paginateStudyGroupMembers_WithDifferentSortConditions_ShouldWorkCorrectly() {
+                // given
+                MemberDto.SearchConditions alphabetSortConditions = MemberDto.SearchConditions.builder()
+                                .sort("alphabet")
+                                .order("asc")
+                                .build();
+
+                Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                                List.of(testMemberResponse), pageable, 1L);
+
+                when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+                when(memberQueryRepository.paginateStudyGroupMembers(
+                                eq(testStudyGroup), eq(alphabetSortConditions), eq(pageable)))
+                                .thenReturn(mockPage);
+
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                1L, alphabetSortConditions, testUserDetails, pageable);
+
+                // then
+                verify(studyGroupRepository, times(1)).findById(1L);
+                verify(memberQueryRepository, times(1))
+                                .paginateStudyGroupMembers(eq(testStudyGroup), eq(alphabetSortConditions),
+                                                eq(pageable));
+
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("다양한 페이징 설정으로 멤버를 조회할 수 있다")
+        void paginateStudyGroupMembers_WithDifferentPageable_ShouldWorkCorrectly() {
+                // given
+                Pageable customPageable = PageRequest.of(1, 5); // 두 번째 페이지, 5개씩
+
+                Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                                List.of(testMemberResponse), customPageable, 1L);
+
+                when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+                when(memberQueryRepository.paginateStudyGroupMembers(
+                                eq(testStudyGroup), eq(searchConditions), eq(customPageable)))
+                                .thenReturn(mockPage);
+
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                1L, searchConditions, testUserDetails, customPageable);
+
+                // then
+                verify(studyGroupRepository, times(1)).findById(1L);
+                verify(memberQueryRepository, times(1))
+                                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions),
+                                                eq(customPageable));
+
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("여러 명의 멤버가 있을 때 모든 결과를 반환한다")
+        void paginateStudyGroupMembers_WithMultipleResults_ShouldReturnAllResults() {
+                // given
+                User secondUser = User.builder()
+                                .id(2L)
+                                .email("second@example.com")
+                                .nickname("secondUser")
+                                .build();
+
+                MemberDto.MemberResponse secondMemberResponse = MemberDto.MemberResponse.builder()
+                                .user(com.depth.learningcrew.domain.user.dto.UserDto.UserResponse.builder()
+                                                .id(secondUser.getId())
+                                                .email(secondUser.getEmail())
+                                                .nickname(secondUser.getNickname())
+                                                .build())
+                                .createdAt(LocalDateTime.now())
+                                .lastModifiedAt(LocalDateTime.now())
+                                .build();
+
+                Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                                List.of(testMemberResponse, secondMemberResponse), pageable, 2L);
+
+                when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+                when(memberQueryRepository.paginateStudyGroupMembers(
+                                eq(testStudyGroup), eq(searchConditions), eq(pageable)))
+                                .thenReturn(mockPage);
+
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                1L, searchConditions, testUserDetails, pageable);
+
+                // then
+                verify(studyGroupRepository, times(1)).findById(1L);
+                verify(memberQueryRepository, times(1))
+                                .paginateStudyGroupMembers(eq(testStudyGroup), eq(searchConditions), eq(pageable));
+
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getContent().get(0).getUser().getId()).isEqualTo(1L);
+                assertThat(result.getContent().get(1).getUser().getId()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("null 검색 조건이 주어져도 기본값으로 처리된다")
+        void paginateStudyGroupMembers_WithNullSearchConditions_ShouldUseDefaultValues() {
+                // given
+                MemberDto.SearchConditions nullConditions = new MemberDto.SearchConditions();
+
+                Page<MemberDto.MemberResponse> mockPage = new PageImpl<>(
+                                List.of(testMemberResponse), pageable, 1L);
+
+                when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(testStudyGroup));
+                when(memberQueryRepository.paginateStudyGroupMembers(
+                                eq(testStudyGroup), eq(nullConditions), eq(pageable)))
+                                .thenReturn(mockPage);
+
+                // when
+                PagedModel<MemberDto.MemberResponse> result = memberService.paginateStudyGroupMembers(
+                                1L, nullConditions, testUserDetails, pageable);
+
+                // then
+                verify(studyGroupRepository, times(1)).findById(1L);
+                verify(memberQueryRepository, times(1))
+                                .paginateStudyGroupMembers(eq(testStudyGroup), eq(nullConditions), eq(pageable));
+
+                assertThat(result).isNotNull();
+                assertThat(result.getContent()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - 성공")
+        void expelMember_Success() {
+                // given
+                Long groupId = 1L;
+                Long userId = 2L;
+                UserDetails userDetails = mock(UserDetails.class);
+                User owner = mock(User.class);
+                User userToExpel = mock(User.class);
+                StudyGroup studyGroup = mock(StudyGroup.class);
+                Member member = mock(Member.class);
+
+                when(userDetails.getUser()).thenReturn(owner);
+                when(owner.getId()).thenReturn(1L);
+                when(userToExpel.getId()).thenReturn(2L);
+                when(studyGroup.getOwner()).thenReturn(owner);
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+                when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
+                when(memberRepository.findById_UserAndId_StudyGroup(userToExpel, studyGroup))
+                                .thenReturn(Optional.of(member));
+
+                // when
+                memberService.expelMember(groupId, userId, userDetails);
+
+                // then
+                verify(memberRepository).delete(member);
+                verify(studyGroup).decreaseMemberCount();
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - owner가 아닌 경우 실패")
+        void expelMember_NotOwner_ThrowsException() {
+                // given
+                Long groupId = 1L;
+                Long userId = 2L;
+                UserDetails userDetails = mock(UserDetails.class);
+                User nonOwner = mock(User.class);
+                User userToExpel = mock(User.class);
+                StudyGroup studyGroup = mock(StudyGroup.class);
+                User owner = mock(User.class);
+
+                when(userDetails.getUser()).thenReturn(nonOwner);
+                when(nonOwner.getId()).thenReturn(3L);
+                when(owner.getId()).thenReturn(1L);
+                when(studyGroup.getOwner()).thenReturn(owner);
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+                when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
+
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - owner 자신을 추방하려는 경우 실패")
+        void expelMember_ExpelOwner_ThrowsException() {
+                // given
+                Long groupId = 1L;
+                Long userId = 1L; // owner의 ID
+                UserDetails userDetails = mock(UserDetails.class);
+                User owner = mock(User.class);
+                StudyGroup studyGroup = mock(StudyGroup.class);
+
+                when(userDetails.getUser()).thenReturn(owner);
+                when(owner.getId()).thenReturn(1L);
+                when(studyGroup.getOwner()).thenReturn(owner);
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+                when(userRepository.findById(userId)).thenReturn(Optional.of(owner));
+
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode",
+                                                ErrorCode.STUDY_GROUP_OWNER_CANNOT_BE_EXPELLED);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - 스터디 그룹이 존재하지 않는 경우 실패")
+        void expelMember_StudyGroupNotFound_ThrowsException() {
+                // given
+                Long groupId = 999L;
+                Long userId = 2L;
+                UserDetails userDetails = mock(UserDetails.class);
+
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 멤버 추방 - 멤버가 존재하지 않는 경우 실패")
+        void expelMember_MemberNotFound_ThrowsException() {
+                // given
+                Long groupId = 1L;
+                Long userId = 2L;
+                UserDetails userDetails = mock(UserDetails.class);
+                User owner = mock(User.class);
+                User userToExpel = mock(User.class);
+                StudyGroup studyGroup = mock(StudyGroup.class);
+
+                when(userDetails.getUser()).thenReturn(owner);
+                when(owner.getId()).thenReturn(1L);
+                when(userToExpel.getId()).thenReturn(2L);
+                when(studyGroup.getOwner()).thenReturn(owner);
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+                when(userRepository.findById(userId)).thenReturn(Optional.of(userToExpel));
+                when(memberRepository.findById_UserAndId_StudyGroup(userToExpel, studyGroup))
+                                .thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService.expelMember(groupId, userId, userDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - 성공")
+        void leaveMember_Success() {
+                // given
+                Long groupId = 1L;
+                UserDetails userDetails = mock(UserDetails.class);
+                User user = mock(User.class);
+                User owner = mock(User.class);
+                StudyGroup studyGroup = mock(StudyGroup.class);
+                Member member = mock(Member.class);
+
+                when(userDetails.getUser()).thenReturn(user);
+                when(user.getId()).thenReturn(2L);
+                when(owner.getId()).thenReturn(1L);
+                when(studyGroup.getOwner()).thenReturn(owner);
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+                when(memberRepository.findById_UserAndId_StudyGroup(user, studyGroup))
+                                .thenReturn(Optional.of(member));
+
+                // when
+                memberService.leaveMember(groupId, userDetails);
+
+                // then
+                verify(memberRepository).delete(member);
+                verify(studyGroup).decreaseMemberCount();
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - owner가 탈퇴하려는 경우 실패")
+        void leaveMember_OwnerCannotLeave_ThrowsException() {
+                // given
+                Long groupId = 1L;
+                UserDetails userDetails = mock(UserDetails.class);
+                User owner = mock(User.class);
+                StudyGroup studyGroup = mock(StudyGroup.class);
+
+                when(userDetails.getUser()).thenReturn(owner);
+                when(owner.getId()).thenReturn(1L);
+                when(studyGroup.getOwner()).thenReturn(owner);
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+
+                // when & then
+                assertThatThrownBy(() -> memberService.leaveMember(groupId, userDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - 그룹에 속하지 않은 유저가 탈퇴하려는 경우 실패")
+        void leaveMember_UserNotInGroup_ThrowsException() {
+                // given
+                Long groupId = 1L;
+                UserDetails userDetails = mock(UserDetails.class);
+                User user = mock(User.class);
+                User owner = mock(User.class);
+                StudyGroup studyGroup = mock(StudyGroup.class);
+
+                when(userDetails.getUser()).thenReturn(user);
+                when(user.getId()).thenReturn(2L);
+                when(owner.getId()).thenReturn(1L);
+                when(studyGroup.getOwner()).thenReturn(owner);
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(studyGroup));
+                when(memberRepository.findById_UserAndId_StudyGroup(user, studyGroup))
+                                .thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService.leaveMember(groupId, userDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("스터디 그룹 탈퇴 - 존재하지 않는 스터디 그룹인 경우 실패")
+        void leaveMember_StudyGroupNotFound_ThrowsException() {
+                // given
+                Long groupId = 999L;
+                UserDetails userDetails = mock(UserDetails.class);
+
+                when(studyGroupRepository.findById(groupId)).thenReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberService.leaveMember(groupId, userDetails))
+                                .isInstanceOf(RestException.class)
+                                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GLOBAL_NOT_FOUND);
+        }
 }


### PR DESCRIPTION
- 스터디 그룹에서 멤버가 탈퇴할 수 있는 leaveMember 메서드 추가
- MemberController에 스터디 그룹 탈퇴 API 엔드포인트 추가
- 탈퇴 시 멤버 수 감소 로직 구현
- owner가 탈퇴할 수 없는 경우 예외 처리 추가

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
