### PR TITLE
LNIT-54-답변-수정-API-구현

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/qna/controller/CommentController.java
+++ b/src/main/java/com/depth/learningcrew/domain/qna/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.depth.learningcrew.domain.qna.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,14 +21,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/study-groups/{studyGroupId}/qna/{qnaId}/comments")
+@RequestMapping("/api/study-groups/{studyGroupId}")
 @RequiredArgsConstructor
 @Tag(name = "Q&A")
 public class CommentController {
 
   private final CommentService commentService;
 
-  @PostMapping
+  @PostMapping("/qna/{qnaId}/comments")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(summary = "댓글(답변) 생성", description = "스터디 그룹 멤버가 질문에 댓글(답변)을 작성합니다.")
   @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
@@ -38,5 +39,17 @@ public class CommentController {
       @AuthenticationPrincipal UserDetails userDetails) {
 
     return commentService.createComment(studyGroupId, qnaId, request, userDetails);
+  }
+
+  @PatchMapping("/comments/{commentId}")
+  @Operation(summary = "댓글(답변) 수정", description = "스터디 그룹 멤버가 작성한 댓글(답변)을 수정합니다. 작성자 또는 스터디 그룹 주최자/관리자만 수정할 수 있습니다.")
+  @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
+  public CommentDto.CommentResponse updateComment(
+      @PathVariable Long studyGroupId,
+      @PathVariable Long commentId,
+      @Valid @ModelAttribute CommentDto.CommentUpdateRequest request,
+      @AuthenticationPrincipal UserDetails userDetails) {
+
+    return commentService.updateComment(studyGroupId, commentId, request, userDetails);
   }
 }

--- a/src/main/java/com/depth/learningcrew/domain/qna/dto/CommentDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/qna/dto/CommentDto.java
@@ -44,6 +44,28 @@ public class CommentDto {
   @NoArgsConstructor
   @Data
   @Builder
+  @Schema(description = "댓글 수정 요청 DTO")
+  public static class CommentUpdateRequest {
+    @Schema(description = "댓글 내용", example = "수정된 답변 내용")
+    private String content;
+
+    @Schema(description = "새로 추가할 첨부 이미지 목록")
+    private List<MultipartFile> newAttachedImages;
+
+    @Schema(description = "새로 추가할 첨부 파일 목록")
+    private List<MultipartFile> newAttachedFiles;
+
+    @Schema(description = "삭제할 첨부 이미지 ID 목록")
+    private List<String> deletedAttachedImages;
+
+    @Schema(description = "삭제할 첨부 파일 ID 목록")
+    private List<String> deletedAttachedFiles;
+  }
+
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Data
+  @Builder
   public static class CommentResponse {
     private Long id;
     private String content;

--- a/src/main/java/com/depth/learningcrew/domain/qna/entity/Comment.java
+++ b/src/main/java/com/depth/learningcrew/domain/qna/entity/Comment.java
@@ -6,6 +6,10 @@ import java.util.List;
 import com.depth.learningcrew.common.auditor.UserStampedEntity;
 import com.depth.learningcrew.domain.file.entity.CommentAttachedFile;
 import com.depth.learningcrew.domain.file.entity.CommentImageFile;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -76,4 +80,20 @@ public class Comment extends UserStampedEntity {
     this.attachedFiles.remove(attachedFile);
     attachedFile.setComment(null);
   }
+
+  public void canUpdateBy(UserDetails user) {
+
+    // 관리자는 수정 가능
+    if (user.getUser().getRole().equals(Role.ADMIN)) {
+      return;
+    }
+
+    // 작성자 본인은 수정 가능
+    if (this.getCreatedBy() != null && this.getCreatedBy().getId().equals(user.getUser().getId())) {
+      return;
+    }
+
+    throw new RestException(ErrorCode.AUTH_FORBIDDEN);
+  }
+
 }

--- a/src/main/java/com/depth/learningcrew/domain/qna/service/CommentService.java
+++ b/src/main/java/com/depth/learningcrew/domain/qna/service/CommentService.java
@@ -55,6 +55,33 @@ public class CommentService {
     return CommentDto.CommentResponse.from(saved);
   }
 
+  @Transactional
+  public CommentDto.CommentResponse updateComment(Long studyGroupId, Long commentId,
+      CommentDto.CommentUpdateRequest request, UserDetails userDetails) {
+
+    StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
+        .orElseThrow(() -> new RestException(ErrorCode.STUDY_GROUP_NOT_FOUND));
+
+    cannotCommentIfNotMember(studyGroup, userDetails);
+
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new RestException(ErrorCode.COMMENT_NOT_FOUND));
+
+    comment.canUpdateBy(userDetails);
+
+    if (request.getContent() != null) {
+      comment.setContent(request.getContent());
+    }
+
+    deleteAttachedImages(request.getDeletedAttachedImages(), comment);
+    deleteAttachedFiles(request.getDeletedAttachedFiles(), comment);
+
+    saveAttachedImages(request.getNewAttachedImages(), comment);
+    saveAttachedFiles(request.getNewAttachedFiles(), comment);
+
+    return CommentDto.CommentResponse.from(comment);
+  }
+
   private void cannotCommentIfNotMember(StudyGroup studyGroup, UserDetails userDetails) {
     if (!memberQueryRepository.isMember(studyGroup, userDetails.getUser())) {
       throw new RestException(ErrorCode.AUTH_FORBIDDEN);
@@ -82,6 +109,38 @@ public class CommentService {
       attached.setComment(comment);
       comment.addAttachedFile(attached);
       fileHandler.saveFile(file, attached);
+    });
+  }
+
+  private void deleteAttachedImages(List<String> imageIds, Comment comment) {
+    if (imageIds == null || imageIds.isEmpty())
+      return;
+
+    imageIds.forEach(id -> {
+      CommentImageFile image = comment.getAttachedImages().stream()
+          .filter(img -> id.equals(img.getUuid()))
+          .findFirst()
+          .orElse(null);
+      if (image != null) {
+        comment.removeAttachedImage(image);
+        fileHandler.deleteFile(image);
+      }
+    });
+  }
+
+  private void deleteAttachedFiles(List<String> fileIds, Comment comment) {
+    if (fileIds == null || fileIds.isEmpty())
+      return;
+
+    fileIds.forEach(id -> {
+      CommentAttachedFile file = comment.getAttachedFiles().stream()
+          .filter(f -> id.equals(f.getUuid()))
+          .findFirst()
+          .orElse(null);
+      if (file != null) {
+        comment.removeAttachedFile(file);
+        fileHandler.deleteFile(file);
+      }
     });
   }
 }

--- a/src/test/java/com/depth/learningcrew/domain/qna/service/CommentServiceIntegrationTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/qna/service/CommentServiceIntegrationTest.java
@@ -1,0 +1,281 @@
+package com.depth.learningcrew.domain.qna.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.file.entity.CommentAttachedFile;
+import com.depth.learningcrew.domain.file.entity.CommentImageFile;
+import com.depth.learningcrew.domain.file.entity.HandlingType;
+import com.depth.learningcrew.domain.file.handler.FileHandler;
+import com.depth.learningcrew.domain.qna.dto.CommentDto;
+import com.depth.learningcrew.domain.qna.entity.Comment;
+import com.depth.learningcrew.domain.qna.entity.QAndA;
+import com.depth.learningcrew.domain.studygroup.entity.Member;
+import com.depth.learningcrew.domain.studygroup.entity.MemberId;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.entity.StudyStep;
+import com.depth.learningcrew.domain.studygroup.entity.StudyStepId;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class CommentServiceIntegrationTest {
+
+  @Autowired
+  private CommentService commentService;
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @MockitoBean
+  private FileHandler fileHandler; // 실제 파일 저장을 막기 위한 목킹
+
+  private static volatile long testCounter = 0;
+  private long currentTestId;
+
+  private User owner;
+  private User member;
+  private User other;
+  private User admin;
+  private UserDetails ownerDetails;
+  private UserDetails memberDetails;
+  private UserDetails otherDetails;
+  private UserDetails adminDetails;
+  private StudyGroup studyGroup;
+  private StudyStep studyStep;
+  private QAndA qna;
+  private Comment comment;
+
+  @BeforeEach
+  void setUp() {
+    currentTestId = ++testCounter;
+
+    entityManager.createQuery("DELETE FROM Comment c").executeUpdate();
+    entityManager.createQuery("DELETE FROM QAndA q").executeUpdate();
+    entityManager.createQuery("DELETE FROM StudyStep s").executeUpdate();
+    entityManager.createQuery("DELETE FROM StudyGroup g").executeUpdate();
+    entityManager.createQuery("DELETE FROM User u").executeUpdate();
+    entityManager.flush();
+    entityManager.clear();
+
+    owner = User.builder()
+        .email("owner_" + currentTestId + "@t.com")
+        .password("p")
+        .nickname("owner_" + currentTestId)
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    member = User.builder()
+        .email("member_" + currentTestId + "@t.com")
+        .password("p")
+        .nickname("member_" + currentTestId)
+        .birthday(LocalDate.of(1992, 2, 2))
+        .gender(Gender.FEMALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    other = User.builder()
+        .email("other_" + currentTestId + "@t.com")
+        .password("p")
+        .nickname("other_" + currentTestId)
+        .birthday(LocalDate.of(1995, 5, 5))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    admin = User.builder()
+        .email("admin_" + currentTestId + "@t.com")
+        .password("p")
+        .nickname("admin_" + currentTestId)
+        .birthday(LocalDate.of(1980, 3, 3))
+        .gender(Gender.MALE)
+        .role(Role.ADMIN)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    entityManager.persist(owner);
+    entityManager.persist(member);
+    entityManager.persist(other);
+    entityManager.persist(admin);
+
+    studyGroup = StudyGroup.builder()
+        .name("sg_" + currentTestId)
+        .summary("sum")
+        .content("content")
+        .maxMembers(10)
+        .memberCount(2)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusMonths(1))
+        .owner(owner)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+    entityManager.persist(studyGroup);
+
+    studyStep = StudyStep.builder()
+        .id(StudyStepId.of(1, studyGroup))
+        .endDate(LocalDate.now().plusDays(30))
+        .build();
+    entityManager.persist(studyStep);
+
+    qna = QAndA.builder()
+        .title("t_" + currentTestId)
+        .content("c_" + currentTestId)
+        .step(1)
+        .studyGroup(studyGroup)
+        .createdBy(member)
+        .lastModifiedBy(member)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+    entityManager.persist(qna);
+
+    // 댓글 생성(작성자: member)
+    comment = Comment.builder()
+        .content("original")
+        .qAndA(qna)
+        .createdBy(member)
+        .lastModifiedBy(member)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+    entityManager.persist(comment);
+    // 멤버십: member, admin을 스터디 그룹 멤버로 추가
+    Member memberMembership = Member.builder().id(MemberId.of(member, studyGroup)).build();
+    Member adminMembership = Member.builder().id(MemberId.of(admin, studyGroup)).build();
+    entityManager.persist(memberMembership);
+    entityManager.persist(adminMembership);
+    entityManager.flush();
+
+    ownerDetails = UserDetails.builder().user(owner).build();
+    memberDetails = UserDetails.builder().user(member).build();
+    otherDetails = UserDetails.builder().user(other).build();
+    adminDetails = UserDetails.builder().user(admin).build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (entityManager != null)
+      entityManager.clear();
+  }
+
+  @Test
+  @DisplayName("댓글 작성자가 자신의 댓글을 수정할 수 있다")
+  void updateComment_ByAuthor_Success() {
+    // when
+    var result = commentService.updateComment(studyGroup.getId(), comment.getId(),
+        CommentDto.CommentUpdateRequest.builder().content("updated").build(), memberDetails);
+
+    // then
+    assertThat(result.getContent()).isEqualTo("updated");
+  }
+
+  @Test
+  @DisplayName("관리자는 댓글을 수정할 수 있다")
+  void updateComment_ByAdmin_Success() {
+    // when
+    var result = commentService.updateComment(studyGroup.getId(), comment.getId(),
+        CommentDto.CommentUpdateRequest.builder().content("admin").build(), adminDetails);
+
+    // then
+    assertThat(result.getContent()).isEqualTo("admin");
+  }
+
+  @Test
+  @DisplayName("권한 없는 사용자는 댓글 수정 불가")
+  void updateComment_Unauthorized_Throws() {
+    // when & then
+    assertThatThrownBy(() -> commentService.updateComment(studyGroup.getId(), comment.getId(),
+        CommentDto.CommentUpdateRequest.builder().content("x").build(), otherDetails))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("새 파일/이미지 추가 및 기존 파일/이미지 삭제를 동시에 수행")
+  void updateComment_ComplexUpdate_Success() {
+    // given 기존 파일/이미지 달기
+    CommentAttachedFile existingFile = CommentAttachedFile.builder()
+        .uuid("ef-" + currentTestId)
+        .fileName("ef.txt")
+        .handlingType(HandlingType.DOWNLOADABLE)
+        .size(10L)
+        .comment(comment)
+        .build();
+    comment.addAttachedFile(existingFile);
+
+    CommentImageFile existingImage = CommentImageFile.builder()
+        .uuid("ei-" + currentTestId)
+        .fileName("ei.jpg")
+        .handlingType(HandlingType.IMAGE)
+        .size(11L)
+        .comment(comment)
+        .build();
+    comment.addAttachedImage(existingImage);
+
+    entityManager.persist(existingFile);
+    entityManager.persist(existingImage);
+    entityManager.flush();
+
+    MockMultipartFile newFile = new MockMultipartFile("newAttachedFiles", "nf.txt", "text/plain", "a".getBytes());
+    MockMultipartFile newImage = new MockMultipartFile("newAttachedImages", "ni.jpg", "image/jpeg", "b".getBytes());
+
+    CommentDto.CommentUpdateRequest req = CommentDto.CommentUpdateRequest.builder()
+        .content("complex")
+        .newAttachedFiles(List.of(newFile))
+        .newAttachedImages(List.of(newImage))
+        .deletedAttachedFiles(List.of(existingFile.getUuid()))
+        .deletedAttachedImages(List.of(existingImage.getUuid()))
+        .build();
+
+    // when
+    var result = commentService.updateComment(studyGroup.getId(), comment.getId(), req, memberDetails);
+
+    // then
+    assertThat(result.getContent()).isEqualTo("complex");
+    verify(fileHandler, times(1)).deleteFile(existingFile);
+    verify(fileHandler, times(1)).deleteFile(existingImage);
+    verify(fileHandler, times(1)).saveFile(org.mockito.ArgumentMatchers.eq(newFile),
+        org.mockito.ArgumentMatchers.any());
+    verify(fileHandler, times(1)).saveFile(org.mockito.ArgumentMatchers.eq(newImage),
+        org.mockito.ArgumentMatchers.any());
+  }
+}

--- a/src/test/java/com/depth/learningcrew/domain/qna/service/CommentServiceTest.java
+++ b/src/test/java/com/depth/learningcrew/domain/qna/service/CommentServiceTest.java
@@ -1,0 +1,347 @@
+package com.depth.learningcrew.domain.qna.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import com.depth.learningcrew.domain.file.entity.CommentAttachedFile;
+import com.depth.learningcrew.domain.file.entity.CommentImageFile;
+import com.depth.learningcrew.domain.file.handler.FileHandler;
+import com.depth.learningcrew.domain.qna.dto.CommentDto;
+import com.depth.learningcrew.domain.qna.entity.Comment;
+import com.depth.learningcrew.domain.qna.repository.CommentRepository;
+import com.depth.learningcrew.domain.qna.repository.QAndARepository;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.repository.MemberQueryRepository;
+import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.domain.user.entity.Gender;
+import com.depth.learningcrew.domain.user.entity.Role;
+import com.depth.learningcrew.domain.user.entity.User;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Mock
+  private QAndARepository qAndARepository;
+
+  @Mock
+  private StudyGroupRepository studyGroupRepository;
+
+  @Mock
+  private MemberQueryRepository memberQueryRepository;
+
+  @Mock
+  private FileHandler fileHandler;
+
+  @InjectMocks
+  private CommentService commentService;
+
+  private User author;
+  private User anotherUser;
+  private User adminUser;
+  private UserDetails authorDetails;
+  private UserDetails anotherDetails;
+  private UserDetails adminDetails;
+  private StudyGroup studyGroup;
+  private Comment comment;
+
+  @BeforeEach
+  void setUp() {
+    author = User.builder()
+        .id(1L)
+        .email("author@test.com")
+        .password("p")
+        .nickname("author")
+        .birthday(LocalDate.of(1990, 1, 1))
+        .gender(Gender.MALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    anotherUser = User.builder()
+        .id(2L)
+        .email("other@test.com")
+        .password("p")
+        .nickname("other")
+        .birthday(LocalDate.of(1992, 2, 2))
+        .gender(Gender.FEMALE)
+        .role(Role.USER)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    adminUser = User.builder()
+        .id(3L)
+        .email("admin@test.com")
+        .password("p")
+        .nickname("admin")
+        .birthday(LocalDate.of(1985, 3, 3))
+        .gender(Gender.MALE)
+        .role(Role.ADMIN)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    authorDetails = UserDetails.builder().user(author).build();
+    anotherDetails = UserDetails.builder().user(anotherUser).build();
+    adminDetails = UserDetails.builder().user(adminUser).build();
+
+    studyGroup = StudyGroup.builder()
+        .id(10L)
+        .name("sg")
+        .summary("sum")
+        .maxMembers(10)
+        .currentStep(1)
+        .startDate(LocalDate.now())
+        .endDate(LocalDate.now().plusDays(1))
+        .owner(author)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+
+    comment = Comment.builder()
+        .id(100L)
+        .content("original content")
+        .attachedFiles(new java.util.ArrayList<>())
+        .attachedImages(new java.util.ArrayList<>())
+        .createdBy(author)
+        .lastModifiedBy(author)
+        .createdAt(LocalDateTime.now())
+        .lastModifiedAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("작성자가 댓글 내용을 수정할 수 있다")
+  void updateComment_ByAuthor_UpdateContent() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, author)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .content("updated")
+        .build();
+
+    // when
+    var result = commentService.updateComment(10L, 100L, request, authorDetails);
+
+    // then
+    assertThat(result.getContent()).isEqualTo("updated");
+    verify(fileHandler, never()).saveFile(any(), any());
+    verify(fileHandler, never()).deleteFile(any());
+  }
+
+  @Test
+  @DisplayName("새 첨부파일/이미지를 추가할 수 있다")
+  void updateComment_AddNewFilesAndImages() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, author)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
+
+    MockMultipartFile file = new MockMultipartFile("newAttachedFiles", "f.txt", "text/plain", "x".getBytes());
+    MockMultipartFile image = new MockMultipartFile("newAttachedImages", "i.jpg", "image/jpeg", "y".getBytes());
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .newAttachedFiles(List.of(file))
+        .newAttachedImages(List.of(image))
+        .build();
+
+    // when
+    var result = commentService.updateComment(10L, 100L, request, authorDetails);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(fileHandler, times(1)).saveFile(eq(file), any());
+    verify(fileHandler, times(1)).saveFile(eq(image), any());
+  }
+
+  @Test
+  @DisplayName("기존 첨부파일/이미지를 삭제할 수 있다")
+  void updateComment_DeleteFilesAndImages() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, author)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
+
+    CommentAttachedFile existingFile = CommentAttachedFile.builder()
+        .uuid("file-uuid")
+        .fileName("file.txt")
+        .build();
+    comment.addAttachedFile(existingFile);
+
+    CommentImageFile existingImage = CommentImageFile.builder()
+        .uuid("img-uuid")
+        .fileName("img.jpg")
+        .build();
+    comment.addAttachedImage(existingImage);
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .deletedAttachedFiles(List.of("file-uuid"))
+        .deletedAttachedImages(List.of("img-uuid"))
+        .build();
+
+    // when
+    var result = commentService.updateComment(10L, 100L, request, authorDetails);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(fileHandler, times(1)).deleteFile(existingFile);
+    verify(fileHandler, times(1)).deleteFile(existingImage);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 첨부 ID 삭제 시도시에도 예외 없이 통과한다")
+  void updateComment_DeleteNonExisting_NoException() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, author)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .deletedAttachedFiles(List.of("not-exist-file"))
+        .deletedAttachedImages(List.of("not-exist-img"))
+        .build();
+
+    // when
+    var result = commentService.updateComment(10L, 100L, request, authorDetails);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(fileHandler, never()).deleteFile(any());
+  }
+
+  @Test
+  @DisplayName("스터디 그룹 멤버가 아니면 수정할 수 없다")
+  void updateComment_NotMember_Forbidden() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, author)).thenReturn(false);
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .content("updated")
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> commentService.updateComment(10L, 100L, request, authorDetails))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("작성자가 아니고 관리자가 아니면 수정할 수 없다")
+  void updateComment_NotAuthorAndNotAdmin_Forbidden() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, anotherUser)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .content("updated")
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> commentService.updateComment(10L, 100L, request, anotherDetails))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("관리자는 댓글을 수정할 수 있다")
+  void updateComment_ByAdmin_Success() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, adminUser)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .content("admin-updated")
+        .build();
+
+    // when
+    var result = commentService.updateComment(10L, 100L, request, adminDetails);
+
+    // then
+    assertThat(result.getContent()).isEqualTo("admin-updated");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 스터디 그룹이면 예외")
+  void updateComment_StudyGroupNotFound() {
+    // given
+    when(studyGroupRepository.findById(999L)).thenReturn(Optional.empty());
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .content("u")
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> commentService.updateComment(999L, 100L, request, authorDetails))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.STUDY_GROUP_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 댓글이면 예외")
+  void updateComment_CommentNotFound() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, author)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.empty());
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .content("u")
+        .build();
+
+    // when & then
+    assertThatThrownBy(() -> commentService.updateComment(10L, 100L, request, authorDetails))
+        .isInstanceOf(RestException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("내용이 null이면 기존 내용 유지")
+  void updateComment_NullContent_KeepsOriginal() {
+    // given
+    when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(studyGroup));
+    when(memberQueryRepository.isMember(studyGroup, author)).thenReturn(true);
+    when(commentRepository.findById(100L)).thenReturn(Optional.of(comment));
+
+    CommentDto.CommentUpdateRequest request = CommentDto.CommentUpdateRequest.builder()
+        .content(null)
+        .build();
+
+    // when
+    var result = commentService.updateComment(10L, 100L, request, authorDetails);
+
+    // then
+    assertThat(result.getContent()).isEqualTo("original content");
+  }
+}


### PR DESCRIPTION
- CommentController에 댓글 수정 API 추가
- CommentDto에 댓글 수정 요청 DTO 추가
- Comment 엔티티에 수정 권한 검증 로직 추가
- CommentService에 댓글 수정 로직 및 파일 첨부/삭제 기능 구현
- 댓글 수정에 대한 통합 및 단위 테스트 추가

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
