### PR TITLE
LNIT-71-스터디의-제목-내용이-스탭별로-할당되도록-수정

### DIFF
--- a/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyStepController.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/controller/StudyStepController.java
@@ -1,0 +1,45 @@
+package com.depth.learningcrew.domain.studygroup.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.depth.learningcrew.domain.studygroup.dto.StepDto;
+import com.depth.learningcrew.domain.studygroup.service.StudyStepService;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-groups/{groupId}/steps")
+@Tag(name = "Study Step", description = "스터디 스텝 조회/수정 API")
+public class StudyStepController {
+
+  private final StudyStepService studyStepService;
+
+  @GetMapping("/{step}")
+  @Operation(summary = "특정 스텝 조회", description = "그룹 ID와 스텝 번호로 스텝 정보를 조회합니다.")
+  public StepDto.StepResponse getStep(
+      @PathVariable Long groupId,
+      @PathVariable Integer step) {
+    return studyStepService.getStep(groupId, step);
+  }
+
+  @PatchMapping("/{step}")
+  @Operation(summary = "특정 스텝 수정", description = "owner 또는 관리자만 스텝의 제목/내용을 수정할 수 있습니다.")
+  public StepDto.StepResponse updateStep(
+      @PathVariable Long groupId,
+      @PathVariable Integer step,
+      @Valid @RequestBody StepDto.StepUpdateRequest request,
+      @AuthenticationPrincipal UserDetails user) {
+    return studyStepService.updateStep(groupId, step, request, user);
+  }
+}

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/StepDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/StepDto.java
@@ -1,13 +1,15 @@
 package com.depth.learningcrew.domain.studygroup.dto;
 
+import java.time.LocalDate;
+
 import com.depth.learningcrew.domain.studygroup.entity.StudyStep;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
+import lombok.Setter;
 
 public class StepDto {
 
@@ -23,11 +25,33 @@ public class StepDto {
         @Schema(description = "스텝 종료 날짜", example = "2025-08-15")
         private LocalDate endDate;
 
+        @Schema(description = "스텝 제목", example = "1주차: 소개와 목표 설정")
+        private String title;
+
+        @Schema(description = "스텝 내용", example = "이 주차에는 스터디 방향을 정하고 환경을 세팅합니다.")
+        private String content;
+
         public static StepResponse from(StudyStep step) {
             return StepResponse.builder()
                     .step(step.getId().getStep())
                     .endDate(step.getEndDate())
+                    .title(step.getTitle())
+                    .content(step.getContent())
                     .build();
         }
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Schema(description = "스텝 수정 요청")
+    public static class StepUpdateRequest {
+        @Schema(description = "스텝 제목", example = "1주차: 소개와 목표 설정")
+        private String title;
+
+        @Schema(description = "스텝 내용", example = "이 주차에는 스터디 방향을 정하고 환경을 세팅합니다.")
+        private String content;
     }
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/dto/StudyGroupDto.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/dto/StudyGroupDto.java
@@ -254,9 +254,6 @@ public class StudyGroupDto {
         @Schema(description = "마지막 수정 시간", example = "2024-01-01T00:00:00")
         private LocalDateTime lastModifiedAt;
 
-        @Schema(description = "스터디 내용", example = "스터디 내용")
-        private String content;
-
         @Schema(description = "스터디 스텝(진도) 목록")
         private List<StepDto.StepResponse> steps;
 
@@ -280,7 +277,6 @@ public class StudyGroupDto {
                     .owner(UserDto.UserResponse.from(studyGroup.getOwner()))
                     .createdAt(studyGroup.getCreatedAt())
                     .lastModifiedAt(studyGroup.getLastModifiedAt())
-                    .content(studyGroup.getContent())
                     .steps(
                             studyGroup.getSteps().stream()
                                     .map(StepDto.StepResponse::from)
@@ -330,7 +326,6 @@ public class StudyGroupDto {
                     .currentStep(1) // 초기 스텝은 1로 설정
                     .startDate(startDate)
                     .endDate(endDate)
-                    .content("") // 초기 내용은 빈 문자열
                     .build();
         }
     }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyGroup.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyGroup.java
@@ -21,7 +21,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -52,10 +51,6 @@ public class StudyGroup extends TimeStampedEntity {
 
     @Column(nullable = false, length = 255)
     private String summary;
-
-    @Lob
-    @Column
-    private String content;
 
     @Column(nullable = false)
     private Integer maxMembers;

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyStep.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/entity/StudyStep.java
@@ -1,19 +1,22 @@
 package com.depth.learningcrew.domain.studygroup.entity;
 
+import java.time.LocalDate;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
+import lombok.Setter;
 
 @Entity
 @Table(name = "STUDY_STEP")
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -22,7 +25,14 @@ public class StudyStep {
     @EmbeddedId
     private StudyStepId id;
 
-    @Column(name="end_date", nullable = false)
+    @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
+
+    @Column(name = "title", length = 255)
+    private String title;
+
+    @Lob
+    @Column(name = "content", columnDefinition = "LONGTEXT")
+    private String content;
 
 }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyGroupService.java
@@ -179,6 +179,8 @@ public class StudyGroupService {
         StudyStep step = StudyStep.builder()
             .id(stepId)
             .endDate(endDate)
+            .title(null)
+            .content(null)
             .build();
         savedGroup.getSteps().add(step);
       }

--- a/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyStepService.java
+++ b/src/main/java/com/depth/learningcrew/domain/studygroup/service/StudyStepService.java
@@ -1,0 +1,58 @@
+package com.depth.learningcrew.domain.studygroup.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.depth.learningcrew.domain.studygroup.dto.StepDto;
+import com.depth.learningcrew.domain.studygroup.entity.StudyGroup;
+import com.depth.learningcrew.domain.studygroup.entity.StudyStep;
+import com.depth.learningcrew.domain.studygroup.entity.StudyStepId;
+import com.depth.learningcrew.domain.studygroup.repository.StudyGroupRepository;
+import com.depth.learningcrew.domain.studygroup.repository.StudyStepRepository;
+import com.depth.learningcrew.system.exception.model.ErrorCode;
+import com.depth.learningcrew.system.exception.model.RestException;
+import com.depth.learningcrew.system.security.model.UserDetails;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StudyStepService {
+
+  private final StudyStepRepository studyStepRepository;
+  private final StudyGroupRepository studyGroupRepository;
+
+  @Transactional(readOnly = true)
+  public StepDto.StepResponse getStep(Long groupId, Integer stepNumber) {
+    StudyGroup group = studyGroupRepository.findById(groupId)
+        .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+    StudyStepId id = StudyStepId.of(stepNumber, group);
+    StudyStep step = studyStepRepository.findById(id)
+        .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+    return StepDto.StepResponse.from(step);
+  }
+
+  @Transactional
+  public StepDto.StepResponse updateStep(Long groupId, Integer stepNumber, StepDto.StepUpdateRequest request,
+      UserDetails user) {
+    StudyGroup group = studyGroupRepository.findById(groupId)
+        .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+    group.canUpdateBy(user);
+
+    StudyStepId id = StudyStepId.of(stepNumber, group);
+    StudyStep step = studyStepRepository.findByIdForUpdate(id)
+        .orElseThrow(() -> new RestException(ErrorCode.GLOBAL_NOT_FOUND));
+
+    if (request.getTitle() != null) {
+      step.setTitle(request.getTitle());
+    }
+    if (request.getContent() != null) {
+      step.setContent(request.getContent());
+    }
+
+    return StepDto.StepResponse.from(step);
+  }
+}


### PR DESCRIPTION
- StudyStepController를 추가하여 스텝 조회 및 수정 기능을 구현
- StepDto에 스텝 제목 및 내용 필드를 추가
- StudyStep 엔티티에 제목 및 내용을 저장할 수 있도록 필드 추가
- StudyStepService에서 스텝 조회 및 수정 로직 구현
- StudyGroupDto에서 스텝 내용 필드 삭제 및 관련 로직 수정

## 📌 PR 개요

- 어떤 변경/기능이 포함되어 있는지 간단히 설명해주세요.

## ✅ 체크리스트

- [ ] 관련 이슈를 연결했나요? (ex. closes #이슈번호)
- [ ] 테스트를 완료했나요?
- [ ] 문서(README 등) 업데이트가 필요한가요?
- [ ] 코드 스타일 가이드(컨벤션 등)를 따랐나요?

## 🔗 참고 사항

- 리뷰어가 참고해야 할 추가 정보, 문서, 스크린샷 등이 있다면 작성해주세요.
